### PR TITLE
Fix masking bug in PolygonalROI in ScanPointGenerator

### DIFF
--- a/org.eclipse.scanning.points/scripts/scanpointgenerator/rois/polygonal_roi.py
+++ b/org.eclipse.scanning.points/scripts/scanpointgenerator/rois/polygonal_roi.py
@@ -62,7 +62,7 @@ class PolygonalROI(ROI):
                 vmask = np.full(len(x), False, dtype=np.int8)
                 vmask |= ((y < v2y) & (y >= v1y))
                 vmask |= ((y < v1y) & (y >= v2y))
-                t = (y - v2y) / (v2y - v1y)
+                t = (y - v1y) / (v2y - v1y)
                 vmask &= x < v1x + t * (v2x - v1x)
                 mask ^= vmask
             v1x, v1y = v2x, v2y


### PR DESCRIPTION
A simple comparison error leads to an incorrect mask being generated,
resulting in invalid points being generated.

This exact fix has been made upstream, in ScanPointGenerator.

Signed-off-by: Charles Mita <charles.mita@diamond.ac.uk>