### PR TITLE
Fix client point generation

### DIFF
--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/points/AbstractGenerator.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/points/AbstractGenerator.java
@@ -32,7 +32,7 @@ public abstract class AbstractGenerator<T> implements IPointGenerator<T>, Iterab
 	protected volatile T model; // Because of the validateModel() method
 	
 	protected List<IPointContainer> containers;
-	protected Collection<Object> regions;
+	protected Collection<Object> regions = new ArrayList<Object>();
 	private String id;
 	private String label;
 	private String description;
@@ -171,13 +171,12 @@ public abstract class AbstractGenerator<T> implements IPointGenerator<T>, Iterab
 
 	@Override
 	public Collection<Object> getRegions() {
-		if (regions!=null) return regions;
-		return null;
+		return regions;
 	}
 
 	@Override
 	public void setRegions(Collection<Object> regions) throws GeneratorException {
-		this.regions = regions;
+		this.regions = regions == null ? new ArrayList<Object>() : regions;
 	}
 
 	public String getId() {

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/points/AbstractPosition.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/points/AbstractPosition.java
@@ -14,10 +14,13 @@ package org.eclipse.scanning.api.points;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 
 public abstract class AbstractPosition implements IPosition, Serializable {
@@ -60,7 +63,8 @@ public abstract class AbstractPosition implements IPosition, Serializable {
 		final int prime = 31;
 		int result = 1;
 		long temp;
-		final Collection<String> names   = getNames();
+		final List<String> names = new ArrayList<String>(getNames());
+		Collections.sort(names);
 		for (String name : names) {
 			Object val = get(name);
 			if (val instanceof Number) {
@@ -96,9 +100,11 @@ public abstract class AbstractPosition implements IPosition, Serializable {
 				return false;
 		}
 
-		final Collection<String> ours   = getNames();
-		final Collection<String> theirs = ((IPosition)obj).getNames();
-		if (!equals(ours, theirs)) return false;		
+		final List<String> ours = new ArrayList<String>(getNames());
+		final List<String> theirs = new ArrayList<String>(((IPosition)obj).getNames());
+		Collections.sort(ours);
+		Collections.sort(theirs);
+		if (!equals(ours, theirs)) return false;
 		for (String name : ours) {
 			Object val1 = get(name);
 			Object val2 = ((IPosition)obj).get(name);
@@ -110,8 +116,17 @@ public abstract class AbstractPosition implements IPosition, Serializable {
 		final Map<String, Integer> iours   = getIndices();
 		final Map<String, Integer> itheirs = getIndices((IPosition)obj);
 		if (!iours.equals(itheirs)) return false;		
-	
-		if (!equals(getDimensionNames(), getDimensionNames((IPosition)obj))) return false;		
+
+		List<List<String>> ourDimNames = getDimensionNames().stream()
+				.map(c -> new ArrayList<String>(c))
+				.collect(Collectors.toList());
+		ourDimNames.forEach(c -> Collections.sort(c));
+		List<List<String>> theirDimNames = getDimensionNames((IPosition) obj).stream()
+				.map(c -> new ArrayList<String>(c))
+				.collect(Collectors.toList());
+		theirDimNames.forEach(c -> Collections.sort(c));
+
+		if (!equals(ourDimNames, theirDimNames)) return false;
 
 		return true;
 	}

--- a/org.eclipse.scanning.points/scripts/jython_spg_interface.py
+++ b/org.eclipse.scanning.points/scripts/jython_spg_interface.py
@@ -276,7 +276,8 @@ class JCompoundGenerator(JavaIteratorWrapper):
                 if isinstance(matched_g1, LineGenerator) \
                         and isinstance(matched_g2, LineGenerator) \
                         and len(excluder.rois) == 1 \
-                        and isinstance(excluder.rois[0], RectangularROI):
+                        and isinstance(excluder.rois[0], RectangularROI) \
+                        and excluder.rois[0].angle == 0:
                     continue
             inner_axis = matched_axes[0]
             inner_idx = self.axes_ordering.index(inner_axis)

--- a/org.eclipse.scanning.points/src/org/eclipse/scanning/points/CompoundSpgIterator.java
+++ b/org.eclipse.scanning.points/src/org/eclipse/scanning/points/CompoundSpgIterator.java
@@ -97,24 +97,12 @@ public class CompoundSpgIterator extends AbstractScanPointIterator {
     
 	@Override
 	public boolean hasNext() {
-		// TODO: Commented out until Python ROIs are ready
-		IPosition point;
-//		double x;
-//		double y;
-		
-		while (pyIterator.hasNext()) {
-			point = pyIterator.next();
-//			x = point.getX();
-//			y = point.getY();
-//			
-//			if (gen.containsPoint(x, y)) {
-			currentPoint = point;
+		if (pyIterator.hasNext()) {
+			currentPoint = pyIterator.next();
 			index++;
-			if (currentPoint!=null) currentPoint.setStepIndex(index);
+			currentPoint.setStepIndex(index);
 			return true;
-//			}
 		}
-		
 		return false;
 	}
 

--- a/org.eclipse.scanning.points/src/org/eclipse/scanning/points/CompoundSpgIterator.java
+++ b/org.eclipse.scanning.points/src/org/eclipse/scanning/points/CompoundSpgIterator.java
@@ -191,55 +191,19 @@ public class CompoundSpgIterator extends AbstractScanPointIterator {
 	 */
 	public static Object[] getExcluders(Collection<?> regions) {
 		LinkedList<Object> pyRegions = new LinkedList<Object>();
-		JythonObjectFactory excluderFactory = ScanPointGeneratorFactory.JExcluderFactory();
-		JythonObjectFactory circularROIFactory = ScanPointGeneratorFactory.JCircularROIFactory();
-		JythonObjectFactory ellipticalROIFactory = ScanPointGeneratorFactory.JEllipticalROIFactory();
-		JythonObjectFactory pointROIFactory = ScanPointGeneratorFactory.JPointROIFactory();
-		JythonObjectFactory polygonalROIFactory = ScanPointGeneratorFactory.JPolygonalROIFactory();
-		JythonObjectFactory rectangularROIFactory = ScanPointGeneratorFactory.JRectangularROIFactory();
-		JythonObjectFactory sectorROIFactory = ScanPointGeneratorFactory.JSectorROIFactory();
-		
+		JythonObjectFactory<?> excluderFactory = ScanPointGeneratorFactory.JExcluderFactory();
 		if (regions != null) {
 			for (Object region : regions) {
-				
 				if (region instanceof ScanRegion) {
-					ScanRegion<?> sr = (ScanRegion<?>)region;
-					Object roi = sr.getRoi();
-					Object pyRoi = null;
-					
-					if (roi instanceof CircularROI) {
-						CircularROI cRoi = (CircularROI) roi;
-						pyRoi = circularROIFactory.createObject(cRoi.getCentre(), cRoi.getRadius());
-					} else if (roi instanceof EllipticalROI) {
-						EllipticalROI eRoi = (EllipticalROI) roi;
-						pyRoi = ellipticalROIFactory.createObject(eRoi.getPoint(), eRoi.getSemiAxes(), eRoi.getAngle());
-					} else if (roi instanceof LinearROI) {
-						// LinearROIs are not supported so do not add
-					} else if (roi instanceof PointROI) {
-						PointROI pRoi = (PointROI) roi;
-						pyRoi = pointROIFactory.createObject(pRoi.getPoint());
-					} else if (roi instanceof PolygonalROI) {
-						PolygonalROI pRoi = (PolygonalROI) roi;
-						double[] xPoints = new double[pRoi.getNumberOfPoints()];
-						double[] yPoints = new double[pRoi.getNumberOfPoints()];
-						for (int i = 0; i < pRoi.getNumberOfPoints(); i++) {
-							PointROI pointRoi = pRoi.getPoint(i);
-							xPoints[i] = pointRoi.getPointX();
-							yPoints[i] = pointRoi.getPointY();
+					ScanRegion<?> sr = (ScanRegion<?>) region;
+					try {
+						Object pyRoi = makePyRoi(region);
+						if (pyRoi != null) {
+							Object pyExcluder = excluderFactory.createObject(pyRoi, sr.getScannables());
+							pyRegions.add(pyExcluder);
 						}
-						pyRoi = polygonalROIFactory.createObject(xPoints, yPoints);
-					} else if (roi instanceof RectangularROI) {
-						RectangularROI rRoi = (RectangularROI) roi;
-						pyRoi = rectangularROIFactory.createObject(rRoi.getPoint(), rRoi.getLength(0), rRoi.getLength(1), rRoi.getAngle());
-					} else if (roi instanceof SectorROI) {
-						SectorROI sRoi = (SectorROI) roi;
-						pyRoi = sectorROIFactory.createObject(sRoi.getPoint(), sRoi.getRadii(), sRoi.getAngles());
-					} else {
-						logger.error("Unsupported ROI tyoe: " + roi.getClass());
-					}
-					if (pyRoi != null) {
-						Object pyExcluder = excluderFactory.createObject(pyRoi, sr.getScannables());
-						pyRegions.add(pyExcluder);
+					} catch (Exception e) {
+						logger.error("Could not convert ROI to PyRoi", e);
 					}
 				} else {
 					logger.error("Region wasn't of type ScanRegion");

--- a/org.eclipse.scanning.points/src/org/eclipse/scanning/points/GridIterator.java
+++ b/org.eclipse.scanning.points/src/org/eclipse/scanning/points/GridIterator.java
@@ -39,7 +39,6 @@ class GridIterator extends AbstractScanPointIterator {
 	private final double yStep;
 	
 	private Point currentPoint;
-	private PyList pyIterators = new PyList();
 
 	public GridIterator(GridGenerator gen) {
 		GridModel model = gen.getModel();
@@ -66,17 +65,10 @@ class GridIterator extends AbstractScanPointIterator {
 		
 		JythonObjectFactory compoundGeneratorFactory = ScanPointGeneratorFactory.JCompoundGeneratorFactory();
         
-        Object[] generators = {outerLine, innerLine};
-        Object[] excluders = {};
-        Object[] mutators = {};
-        
-		@SuppressWarnings("unchecked")
-		Iterator<IPosition> iterator = (Iterator<IPosition>)  compoundGeneratorFactory.createObject(
-				generators, excluders, mutators);
-        pyIterator = iterator;
-        
-        pyIterators.add(outerLine);
-        pyIterators.add(innerLine);
+        Iterator<?>[] generators = {outerLine, innerLine};
+
+		pyIterator = createSpgCompoundGenerator(generators, gen.getRegions().toArray(),
+				new String[] {xName, yName}, new PyObject[] {});
 	}
 
 	public GridIterator(RandomOffsetGridGenerator gen) {
@@ -116,17 +108,11 @@ class GridIterator extends AbstractScanPointIterator {
         
         JythonObjectFactory compoundGeneratorFactory = ScanPointGeneratorFactory.JCompoundGeneratorFactory();
         
-        Object[] generators = {outerLine, innerLine};
-        Object[] excluders = {};
-        Object[] mutators = {randomOffset};
+        Iterator<?>[] generators = {outerLine, innerLine};
+        PyObject[] mutators = {randomOffset};
         
-		@SuppressWarnings("unchecked")
-		Iterator<IPosition> iterator = (Iterator<IPosition>)  compoundGeneratorFactory.createObject(
-				generators, excluders, mutators);
-        pyIterator = iterator;
-        
-        pyIterators.add(outerLine);
-        pyIterators.add(innerLine);
+		pyIterator = createSpgCompoundGenerator(generators, gen.getRegions().toArray(),
+				new String[] {xName, yName}, mutators);
 	}
 
 	public GridIterator(RasterGenerator gen) {
@@ -153,17 +139,10 @@ class GridIterator extends AbstractScanPointIterator {
 		
 		JythonObjectFactory compoundGeneratorFactory = ScanPointGeneratorFactory.JCompoundGeneratorFactory();
         
-        Object[] generators = {outerLine, innerLine};
-        Object[] excluders = {};
-        Object[] mutators = {};
-        
-		@SuppressWarnings("unchecked")
-		Iterator<IPosition> iterator = (Iterator<IPosition>)  compoundGeneratorFactory.createObject(
-				generators, excluders, mutators);
-        pyIterator = iterator;
-        
-        pyIterators.add(outerLine);
-        pyIterators.add(innerLine);
+        Iterator<?>[] generators = {outerLine, innerLine};
+
+		pyIterator = createSpgCompoundGenerator(generators, gen.getRegions().toArray(),
+				new String[] {xName, yName}, new PyObject[] {});
 	}
 
 	@Override

--- a/org.eclipse.scanning.points/src/org/eclipse/scanning/points/GridIterator.java
+++ b/org.eclipse.scanning.points/src/org/eclipse/scanning/points/GridIterator.java
@@ -147,20 +147,13 @@ class GridIterator extends AbstractScanPointIterator {
 
 	@Override
 	public boolean hasNext() {
-		Point point;
-		
-		while (pyIterator.hasNext()) {
-			point = (Point) pyIterator.next();
-			
-			if (gen.containsPoint(point)) {
-				currentPoint = point;
-				return true;
-			}
+		if (pyIterator.hasNext()) {
+			currentPoint = (Point) pyIterator.next();
+			return true;
 		}
-		
 		return false;
 	}
-	
+
 	@Override
 	public Point next() {
 		// TODO: This will return null if called without calling hasNext() and when the

--- a/org.eclipse.scanning.points/src/org/eclipse/scanning/points/LissajousIterator.java
+++ b/org.eclipse.scanning.points/src/org/eclipse/scanning/points/LissajousIterator.java
@@ -60,15 +60,9 @@ class LissajousIterator extends AbstractScanPointIterator {
 
 	@Override
 	public boolean hasNext() {
-		Point point;
-		
-		while (pyIterator.hasNext()) {
-			point = (Point) pyIterator.next();
-			
-			if (gen.containsPoint(point)) {
-				currentPoint = point;
-				return true;
-			}
+		if (pyIterator.hasNext()) {
+			currentPoint = (Point) pyIterator.next();
+			return true;
 		}
 		
 		return false;

--- a/org.eclipse.scanning.points/src/org/eclipse/scanning/points/LissajousIterator.java
+++ b/org.eclipse.scanning.points/src/org/eclipse/scanning/points/LissajousIterator.java
@@ -20,6 +20,7 @@ import org.eclipse.scanning.api.points.models.LissajousModel;
 import org.eclipse.scanning.jython.JythonObjectFactory;
 import org.python.core.PyDictionary;
 import org.python.core.PyList;
+import org.python.core.PyObject;
 
 class LissajousIterator extends AbstractScanPointIterator {
 
@@ -37,7 +38,7 @@ class LissajousIterator extends AbstractScanPointIterator {
 		double width = model.getBoundingBox().getFastAxisLength();
 		double height = model.getBoundingBox().getSlowAxisLength();
 		
-        JythonObjectFactory lissajousGeneratorFactory = ScanPointGeneratorFactory.JLissajousGeneratorFactory();
+        JythonObjectFactory<?> lissajousGeneratorFactory = ScanPointGeneratorFactory.JLissajousGeneratorFactory();
 
         PyDictionary box = new PyDictionary();
         box.put("width", width);
@@ -51,9 +52,10 @@ class LissajousIterator extends AbstractScanPointIterator {
         int numPoints = model.getPoints();
         
         @SuppressWarnings("unchecked")
-		Iterator<IPosition> iterator = (Iterator<IPosition>) lissajousGeneratorFactory.createObject(
+		Iterator<IPosition> lissajous = (Iterator<IPosition>) lissajousGeneratorFactory.createObject(
 				names, units, box, numLobes, numPoints);
-        pyIterator = iterator;
+		pyIterator = createSpgCompoundGenerator(new Iterator[] {lissajous}, gen.getRegions().toArray(),
+				new String[] {xName, yName}, new PyObject[] {});
 	}
 
 	@Override

--- a/org.eclipse.scanning.points/src/org/eclipse/scanning/points/SpiralIterator.java
+++ b/org.eclipse.scanning.points/src/org/eclipse/scanning/points/SpiralIterator.java
@@ -19,6 +19,7 @@ import org.eclipse.scanning.api.points.Point;
 import org.eclipse.scanning.api.points.models.SpiralModel;
 import org.eclipse.scanning.jython.JythonObjectFactory;
 import org.python.core.PyList;
+import org.python.core.PyObject;
 
 class SpiralIterator extends AbstractScanPointIterator {
 
@@ -55,9 +56,10 @@ class SpiralIterator extends AbstractScanPointIterator {
         boolean alternate = false;
         
         @SuppressWarnings("unchecked")
-		Iterator<IPosition> iterator = (Iterator<IPosition>) spiralGeneratorFactory.createObject(
+		Iterator<IPosition> spiral = (Iterator<IPosition>) spiralGeneratorFactory.createObject(
 				names, units, centre, radius, scale, alternate);
-		pyIterator = iterator;
+		pyIterator = createSpgCompoundGenerator(new Iterator<?>[] {spiral}, gen.getRegions().toArray(),
+				new String[] {xName, yName}, new PyObject[] {});
 	}
 
 	@Override

--- a/org.eclipse.scanning.points/src/org/eclipse/scanning/points/SpiralIterator.java
+++ b/org.eclipse.scanning.points/src/org/eclipse/scanning/points/SpiralIterator.java
@@ -64,18 +64,11 @@ class SpiralIterator extends AbstractScanPointIterator {
 
 	@Override
 	public boolean hasNext() {
-		Point point;
-		
-		while (pyIterator.hasNext()) {
-			point = (Point) pyIterator.next();
-			
-			if (gen.containsPoint(point)) {
-				currentPoint = point;
-				return true;
-			}
+		if (pyIterator.hasNext()) {
+			currentPoint = (Point) pyIterator.next();
+			return true;
 		}
-		
-		return false;		
+		return false;
 	}
 
 	@Override

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/points/GridTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/points/GridTest.java
@@ -370,11 +370,11 @@ public class GridTest extends GeneratorTest {
 
 		assertEquals(pointList.size(), 3156);
 //		GeneratorUtil.testGeneratorPoints(gen); // Rounding error in here causing test to fail
-		assertEquals(new Point(69, 1.0425, 0, 13.575), pointList.get(0));
-		assertEquals(new Point(70, 1.0575, 0, 13.575), pointList.get(1));
-		assertEquals(new Point(17, 0.2625, 7, 14.625), pointList.get(1000));
-		assertEquals(new Point(27, 0.4125, 12, 15.375), pointList.get(2000));
-		assertEquals(new Point(75, 1.1325, 19, 16.425), pointList.get(3100));
+		assertEquals(new Point(0, 1.0425, 0, 13.575), pointList.get(0));
+		assertEquals(new Point(1, 1.0575, 1, 13.575), pointList.get(1));
+		assertEquals(new Point(1000, 0.2625, 1000, 14.625), pointList.get(1000));
+		assertEquals(new Point(2000, 0.4125, 2000, 15.375), pointList.get(2000));
+		assertEquals(new Point(3100, 1.1325, 3100, 16.425), pointList.get(3100));
 	}
 
 	@Test

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/points/RasterTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/points/RasterTest.java
@@ -210,13 +210,13 @@ public class RasterTest {
 		assertEquals(5, pointList.size());
 
 		// Check the points are correct and the order is maintained
-        assertEquals(new Point(1, 0.0, 0, -1.0), pointList.get(0));
-        assertEquals(new Point(0, -1.0, 1, 0.0), pointList.get(1));
-        assertEquals(new Point(1, 0.0, 1, 0.0), pointList.get(2));
-        assertEquals(new Point(2, 1.0, 1, 0.0), pointList.get(3));
-        assertEquals(new Point(1, 0.0, 2, 1.0), pointList.get(4));
+        assertEquals(new Point(0, 0.0, 0, -1.0), pointList.get(0));
+        assertEquals(new Point(1, -1.0, 1, 0.0), pointList.get(1));
+        assertEquals(new Point(2, 0.0, 2, 0.0), pointList.get(2));
+        assertEquals(new Point(3, 1.0, 3, 0.0), pointList.get(3));
+        assertEquals(new Point(4, 0.0, 4, 1.0), pointList.get(4));
 		
-        GeneratorUtil.testGeneratorPoints(gen, 3, 2);
+        GeneratorUtil.testGeneratorPoints(gen, 5);
 	}
 
 	


### PR DESCRIPTION
Changes the Java iterators that wrap ScanPointGenerator generators
to properly apply regions/mutators, unifying the way points are generated.

This means that there should be no mismatch between points the GUI
displays and the actual scan path.