### PR TITLE
I15-1 (9.4pre) Add support for multi-value device values in a DeviceR…

### DIFF
--- a/org.eclipse.scanning.api/META-INF/MANIFEST.MF
+++ b/org.eclipse.scanning.api/META-INF/MANIFEST.MF
@@ -46,4 +46,5 @@ Export-Package: org.eclipse.scanning.api,
  org.eclipse.scanning.api.ui,
  org.eclipse.scanning.api.ui.auto
 Import-Package: org.slf4j
+Require-Bundle: com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.2.0"
 

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/scan/DeviceValueMultiPosition.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/scan/DeviceValueMultiPosition.java
@@ -1,0 +1,82 @@
+/*-
+ * Copyright © 2017 Diamond Light Source Ltd.
+ *
+ * This file is part of GDA.
+ *
+ * GDA is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License version 3 as published by the Free
+ * Software Foundation.
+ *
+ * GDA is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with GDA. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.eclipse.scanning.api.event.scan;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * This is a special Position class to allow both x and y gap values to be returned from a
+ * NexusSlitsWrapper scannable. It is a temporary creation until we understand why can't
+ * use a List or a Map for a DeviceValue in a DeviceRequest. 
+ *
+ */
+public class DeviceValueMultiPosition {
+	@JsonProperty("values")
+	private List<Double> values = new ArrayList<Double>() {{
+		add(0.0);
+		add(0.0);
+	}};
+
+	public double getX_gap() {
+		return values.get(0);
+	}
+
+	public void setX_gap(double x_gap) {
+		values.set(0, x_gap);
+	}
+
+	public double getY_gap() {
+		return values.get(1);
+	}
+
+	public void setY_gap(double y_gap) {
+		values.set(1, y_gap);
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		long temp;
+		temp = Double.doubleToLongBits(getX_gap());
+		result = prime * result + (int) (temp ^ (temp >>> 32));
+		temp = Double.doubleToLongBits(getY_gap());
+		result = prime * result + (int) (temp ^ (temp >>> 32));
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		DeviceValueMultiPosition other = (DeviceValueMultiPosition) obj;
+		if (Double.doubleToLongBits(getX_gap()) != Double.doubleToLongBits(other.getX_gap()))
+			return false;
+		if (Double.doubleToLongBits(getY_gap()) != Double.doubleToLongBits(other.getY_gap()))
+			return false;
+		return true;
+	}
+}

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/scan/NexusSlitsPosition.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/scan/NexusSlitsPosition.java
@@ -1,0 +1,86 @@
+/*-
+ * Copyright © 2017 Diamond Light Source Ltd.
+ *
+ * This file is part of GDA.
+ *
+ * GDA is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License version 3 as published by the Free
+ * Software Foundation.
+ *
+ * GDA is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with GDA. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.eclipse.scanning.api.event.scan;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This is a special Position class to allow both x and y gap values to be returned from a
+ * NexusSlitsWrapper scannable. It is a temporary creation until we understand why can't
+ * use a List or a Map for a DeviceValue in a DeviceRequest. 
+ *
+ */
+public class NexusSlitsPosition {
+	private double x_gap;
+	private double y_gap;
+
+	public double getX_gap() {
+		return x_gap;
+	}
+
+	public void setX_gap(double x_gap) {
+		this.x_gap = x_gap;
+	}
+
+	public double getY_gap() {
+		return y_gap;
+	}
+
+	public void setY_gap(double y_gap) {
+		this.y_gap = y_gap;
+	}
+
+	public List<Double> getPositionList() {
+		return Arrays.asList(getX_gap(), getY_gap());
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		long temp;
+		temp = Double.doubleToLongBits(x_gap);
+		result = prime * result + (int) (temp ^ (temp >>> 32));
+		temp = Double.doubleToLongBits(y_gap);
+		result = prime * result + (int) (temp ^ (temp >>> 32));
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		NexusSlitsPosition other = (NexusSlitsPosition) obj;
+		if (Double.doubleToLongBits(x_gap) != Double.doubleToLongBits(other.x_gap))
+			return false;
+		if (Double.doubleToLongBits(y_gap) != Double.doubleToLongBits(other.y_gap))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "NexusSlitsPosition [x_gap=" + x_gap + ", y_gap=" + y_gap + "]";
+	}
+}

--- a/org.eclipse.scanning.points/src/org/eclipse/scanning/points/classregistry/ScanningAPIClassRegistry.java
+++ b/org.eclipse.scanning.points/src/org/eclipse/scanning/points/classregistry/ScanningAPIClassRegistry.java
@@ -30,6 +30,8 @@ import org.eclipse.scanning.api.event.queues.beans.TaskBean;
 import org.eclipse.scanning.api.event.queues.remote.QueueRequest;
 import org.eclipse.scanning.api.event.scan.AcquireRequest;
 import org.eclipse.scanning.api.event.scan.DeviceRequest;
+import org.eclipse.scanning.api.event.scan.DeviceValueMultiPosition;
+import org.eclipse.scanning.api.event.scan.NexusSlitsPosition;
 import org.eclipse.scanning.api.event.scan.PositionerRequest;
 import org.eclipse.scanning.api.event.scan.SampleData;
 import org.eclipse.scanning.api.event.scan.ScanBean;
@@ -109,6 +111,8 @@ public class ScanningAPIClassRegistry implements IClassRegistry {
 		registerClass(tmp, SampleData.class);
 		registerClass(tmp, ScanRequest.class);
 		registerClass(tmp, ScanMetadata.class);
+		registerClass(tmp, NexusSlitsPosition.class);
+		registerClass(tmp, DeviceValueMultiPosition.class);
 		
 		// points
 		registerClass(tmp, StaticPosition.class);

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/SerializationTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/SerializationTest.java
@@ -21,8 +21,12 @@ import java.io.InputStream;
 import java.io.ObjectInput;
 import java.io.ObjectInputStream;
 import java.net.InetAddress;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.eclipse.dawnsci.analysis.api.persistence.IMarshallerService;
@@ -33,7 +37,11 @@ import org.eclipse.dawnsci.analysis.dataset.roi.RectangularROI;
 import org.eclipse.dawnsci.json.MarshallerService;
 import org.eclipse.scanning.api.INamedNode;
 import org.eclipse.scanning.api.ISpringParser;
+import org.eclipse.scanning.api.annotation.ui.DeviceType;
+import org.eclipse.scanning.api.event.scan.DeviceRequest;
 import org.eclipse.scanning.api.event.scan.DeviceState;
+import org.eclipse.scanning.api.event.scan.DeviceValueMultiPosition;
+import org.eclipse.scanning.api.event.scan.NexusSlitsPosition;
 import org.eclipse.scanning.api.event.scan.ScanBean;
 import org.eclipse.scanning.api.event.scan.ScanRequest;
 import org.eclipse.scanning.api.event.status.Status;
@@ -58,6 +66,7 @@ import org.eclipse.scanning.server.application.PseudoSpringParser;
 import org.eclipse.scanning.test.ScanningTestClassRegistry;
 import org.eclipse.scanning.test.scan.mock.MockDetectorModel;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class SerializationTest {
@@ -466,4 +475,98 @@ public class SerializationTest {
 		assertTrue(bean.getScanRequest()==null);
 	}
 
+	@Test
+	public void testSerializeDeviceRequestWithNumber() throws Exception {
+		Number value = 1.234;
+		
+		final DeviceRequest sent = new DeviceRequest("devicerequesttest", DeviceType.SCANNABLE, null, value);
+		
+        String json = service.marshal(sent);
+        
+        DeviceRequest ret = service.unmarshal(json, DeviceRequest.class);
+        
+        if (!ret.equals(sent)) throw new Exception("Cannot deserialize "+DeviceRequest.class.getName());
+        if (!ret.getDeviceValue().equals(sent.getDeviceValue())) throw new Exception("Cannot deserialize "+DeviceRequest.class.getName());
+	}
+
+	@Test @Ignore
+	public void testSerializeDeviceRequestWithDoubleList() throws Exception {
+		List<Double> value = Arrays.asList(1.234, 2.345);
+		
+		final DeviceRequest sent = new DeviceRequest("devicerequesttest", DeviceType.SCANNABLE, null, value);
+		
+        String json = service.marshal(sent); // TODO: Work out why this fails
+        
+        DeviceRequest ret = service.unmarshal(json, DeviceRequest.class);
+        
+        if (!ret.equals(sent)) throw new Exception("Cannot deserialize "+DeviceRequest.class.getName());
+        if (!ret.getDeviceValue().equals(sent.getDeviceValue())) throw new Exception("Cannot deserialize "+DeviceRequest.class.getName());
+	}
+
+	@Test @Ignore
+	public void testSerializeDeviceRequestWithArrayList() throws Exception {
+		ArrayList value = new ArrayList();
+		value.add(1.234);
+		value.add(2.345);
+		
+		final DeviceRequest sent = new DeviceRequest("devicerequesttest", DeviceType.SCANNABLE, null, value);
+		
+        String json = service.marshal(sent); // TODO: Work out why this fails
+        
+        DeviceRequest ret = service.unmarshal(json, DeviceRequest.class);
+        
+        if (!ret.equals(sent)) throw new Exception("Cannot deserialize "+DeviceRequest.class.getName());
+        if (!ret.getDeviceValue().equals(sent.getDeviceValue())) throw new Exception("Cannot deserialize "+DeviceRequest.class.getName());
+	}
+
+	@Test @Ignore
+	public void testSerializeDeviceRequestWithHashMap() throws Exception {
+		Map<String, Double> value = new HashMap<String, Double>() {
+			private static final long serialVersionUID = 1L;
+		{
+			put("x_gap", 1.234);
+			put("y_gap", 5.678);
+		}};
+		
+		final DeviceRequest sent = new DeviceRequest("devicerequesttest", DeviceType.SCANNABLE, null, value);
+		
+        String json = service.marshal(sent); // TODO: Work out why this fails
+        
+        DeviceRequest ret = service.unmarshal(json, DeviceRequest.class);
+        
+        if (!ret.equals(sent)) throw new Exception("Cannot deserialize "+DeviceRequest.class.getName());
+        if (!ret.getDeviceValue().equals(sent.getDeviceValue())) throw new Exception("Cannot deserialize "+DeviceRequest.class.getName());
+	}
+
+	@Test
+	public void testSerializeDeviceRequestWithNexusSlitsPosition() throws Exception {
+		NexusSlitsPosition value = new NexusSlitsPosition();
+		value.setX_gap(1.234);
+		value.setY_gap(5.678);
+		
+		final DeviceRequest sent = new DeviceRequest("devicerequesttest", DeviceType.SCANNABLE, null, value);
+		
+        String json = service.marshal(sent);
+        
+        DeviceRequest ret = service.unmarshal(json, DeviceRequest.class);
+        
+        if (!ret.equals(sent)) throw new Exception("Cannot deserialize "+DeviceRequest.class.getName());
+        if (!ret.getDeviceValue().equals(sent.getDeviceValue())) throw new Exception("Cannot deserialize "+DeviceRequest.class.getName());
+	}
+
+	@Test
+	public void testSerializeDeviceRequestWithDeviceValueMultiPosition() throws Exception {
+		DeviceValueMultiPosition value = new DeviceValueMultiPosition();
+		value.setX_gap(1.234);
+		value.setY_gap(5.678);
+
+		final DeviceRequest sent = new DeviceRequest("devicerequesttest", DeviceType.SCANNABLE, null, value);
+		
+        String json = service.marshal(sent);
+        
+        DeviceRequest ret = service.unmarshal(json, DeviceRequest.class);
+        
+        if (!ret.equals(sent)) throw new Exception("Cannot deserialize "+DeviceRequest.class.getName());
+        if (!ret.getDeviceValue().equals(sent.getDeviceValue())) throw new Exception("Cannot deserialize "+DeviceRequest.class.getName());
+	}
 }


### PR DESCRIPTION
…equest.

Although the documentation suggests that we should be able to pass
Collections through the DeviceRequest.deviceValue this does not appear
to work (which is why testSerializeDeviceRequestWithDoubleList, 
testSerializeDeviceRequestWithArrayList & testSerializeDeviceRequestWithHashMap
are all @Ignored).

Instead we currently have to create a class with explicit properties, see NexusSlitsPosition, or one which contains a Collection which has the
@JsonProperty annotation added to Collection classes, see DeviceValueMultiPosition.

Ultimately we shouldn't need these classes, but for the moment this is
the most expedient way to add this required functionality.