### PR TITLE
DAQ-524 Use exposure time as timeout for device if not explicitly set

### DIFF
--- a/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/DeviceRunner.java
+++ b/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/DeviceRunner.java
@@ -74,9 +74,9 @@ class DeviceRunner extends LevelRunner<IRunnableDevice<?>> {
 		long timeout = -1;
 		if (model instanceof ITimeoutable) {
 			timeout = ((ITimeoutable)model).getTimeout();
-			if (timeout<0 && model instanceof IDetectorModel) {
+			if (timeout <= 0 && model instanceof IDetectorModel) {
 				IDetectorModel dmodel = (IDetectorModel)model;
-				timeout = Math.round(dmodel.getExposureTime());
+				timeout = Math.round(dmodel.getExposureTime() + 1);
 			}
 		} else if (model instanceof IDetectorModel) {
 			IDetectorModel dmodel = (IDetectorModel)model;


### PR DESCRIPTION
Previously, exposure time was used as timeout only if timeout had
been set negative. This changes the test to zero or negative
(so handling the cases where timeout has not been set) and also adds
an extra second to the timeout to allow for latency.

Signed-off-by: Anthony Hull <anthony.hull@diamond.ac.uk>