### PR TITLE
[DAQ-575] Added UiHidden annotation to get methods in AbstractPosition

### DIFF
--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/points/AbstractPosition.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/points/AbstractPosition.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.eclipse.scanning.api.annotation.UiHidden;
+
 
 public abstract class AbstractPosition implements IPosition, Serializable {
 	
@@ -32,6 +34,7 @@ public abstract class AbstractPosition implements IPosition, Serializable {
 	private int stepIndex = -1;
 	protected List<Collection<String>> dimensionNames; // Dimension->Names@dimension
 	
+	@UiHidden
 	public int getStepIndex() {
 		return stepIndex;
 	}
@@ -227,6 +230,7 @@ public abstract class AbstractPosition implements IPosition, Serializable {
 	 * 
 	 * @return
 	 */
+	@UiHidden
 	public synchronized List<Collection<String>> getDimensionNames() {
 		if (dimensionNames==null||dimensionNames.isEmpty())  {
 			dimensionNames = new ArrayList<>();
@@ -239,6 +243,7 @@ public abstract class AbstractPosition implements IPosition, Serializable {
 	}
 
 	@Override
+	@UiHidden
 	public int getScanRank() {
 		return getDimensionNames().size();
 	}


### PR DESCRIPTION
These fields should not be visible to the user. The only fields
visible to the user should be, e.g. X, Y for a point.

Signed-off-by: Matthew Dickie <matthew.dickie@diamond.ac.uk>