### PR TITLE
Added timeout

### DIFF
--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/AbstractScannable.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/AbstractScannable.java
@@ -49,6 +49,7 @@ public abstract class AbstractScannable<T> implements IScannable<T>, IScanAttrib
 	private String              name;
 	private boolean             activated;
 	private MonitorRole         monitorRole=MonitorRole.PER_POINT;
+	private long                timeout=-1;
 	
 	/**
 	 * Model is used for some scannables for instance those writing NeXus 
@@ -261,5 +262,13 @@ public abstract class AbstractScannable<T> implements IScannable<T>, IScanAttrib
 		this.monitorRole = monitorRole;
 		return orig;
 	}
-	
+	@Override
+	public long getTimeout() {
+		return timeout;
+	}
+	@Override
+	public void setTimeout(long timeout) {
+		this.timeout = timeout;
+	}
+
 }

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/ITimeoutable.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/ITimeoutable.java
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.eclipse.scanning.api;
 
-import org.eclipse.scanning.api.annotation.UiHidden;
 
 public interface ITimeoutable {
 
@@ -30,7 +29,6 @@ public interface ITimeoutable {
 	 * 
 	 * @return
 	 */
-	@UiHidden
 	default long getTimeout() {
 		return -1;
 	}
@@ -39,7 +37,6 @@ public interface ITimeoutable {
 	 * 
 	 * @param time in seconds
 	 */
-	@UiHidden
 	default void setTimeout(long time) {
 		// Does nothing
 	}

--- a/org.eclipse.scanning.command/OSGI-INF/services.xml
+++ b/org.eclipse.scanning.command/OSGI-INF/services.xml
@@ -4,4 +4,5 @@
    <reference bind="setRunnableDeviceService" cardinality="0..1" interface="org.eclipse.scanning.api.device.IRunnableDeviceService" name="IRunnableDeviceService" policy="dynamic"/>
    <reference bind="setEventService" cardinality="0..1" interface="org.eclipse.scanning.api.event.IEventService" name="IEventService" policy="dynamic"/>
    <reference bind="setGeneratorService" cardinality="0..1" interface="org.eclipse.scanning.api.points.IPointGeneratorService" name="IPointGeneratorService" policy="dynamic"/>
+   <reference bind="setScannableDeviceService" cardinality="0..1" interface="org.eclipse.scanning.api.device.IScannableDeviceService" name="IScannableDeviceService" policy="dynamic"/>
 </scr:component>

--- a/org.eclipse.scanning.command/src/org/eclipse/scanning/command/Services.java
+++ b/org.eclipse.scanning.command/src/org/eclipse/scanning/command/Services.java
@@ -12,6 +12,7 @@
 package org.eclipse.scanning.command;
 
 import org.eclipse.scanning.api.device.IRunnableDeviceService;
+import org.eclipse.scanning.api.device.IScannableDeviceService;
 import org.eclipse.scanning.api.event.IEventService;
 import org.eclipse.scanning.api.points.IPointGeneratorService;
 
@@ -29,6 +30,15 @@ public class Services {
 	private static IEventService           eventService;
 	private static IPointGeneratorService  generatorService;
 	private static IRunnableDeviceService  runnableDeviceService;
+	private static IScannableDeviceService scannableDeviceService;
+
+	public static IScannableDeviceService getScannableDeviceService() {
+		return scannableDeviceService;
+	}
+
+	public static void setScannableDeviceService(IScannableDeviceService scannableDeviceService) {
+		Services.scannableDeviceService = scannableDeviceService;
+	}
 
 	public static IEventService getEventService() {
 		return eventService;

--- a/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/ScannablePositioner.java
+++ b/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/ScannablePositioner.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 import org.eclipse.scanning.api.IScannable;
-import org.eclipse.scanning.api.device.AbstractRunnableDevice;
 import org.eclipse.scanning.api.device.IScannableDeviceService;
 import org.eclipse.scanning.api.points.IPosition;
 import org.eclipse.scanning.api.points.MapPosition;
@@ -60,9 +59,7 @@ final class ScannablePositioner extends LevelRunner<IScannable<?>> implements IP
 		
 		long time = Long.MIN_VALUE;
 		for (IScannable<?> device : objects) {
-			if (device instanceof AbstractRunnableDevice) {
-				time = Math.max(time, device.getTimeout());
-			}
+			time = Math.max(time, device.getTimeout());
 		}
 		if (time<0) time = defaultTimeout; // seconds
 		return time;

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/command/AbstractScanCommandsTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/command/AbstractScanCommandsTest.java
@@ -140,12 +140,13 @@ public abstract class AbstractScanCommandsTest extends AbstractJythonTest {
 		// Provide lots of services that OSGi would normally.
 		Services.setEventService(eservice);
 		ServiceHolder.setEventService(eservice);
-		org.eclipse.scanning.command.Services.setEventService(eservice);
 		Services.setRunnableDeviceService(dservice);
-		org.eclipse.scanning.command.Services.setRunnableDeviceService(dservice);
 		Services.setGeneratorService(gservice);
 		Services.setConnector(connector);
 		Services.setWatchdogService(wservice);
+		org.eclipse.scanning.command.Services.setEventService(eservice);
+		org.eclipse.scanning.command.Services.setRunnableDeviceService(dservice);
+		org.eclipse.scanning.command.Services.setScannableDeviceService(connector);
 
 		org.eclipse.scanning.sequencer.ServiceHolder.setTestServices(lservice,
 				                                                     new DefaultNexusBuilderFactory(), 

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/command/MScanTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/command/MScanTest.java
@@ -1,5 +1,8 @@
 package org.eclipse.scanning.test.command;
 
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.scanning.command.Services;
 import org.junit.Test;
 
 public class MScanTest extends AbstractScanCommandsTest {
@@ -32,6 +35,25 @@ public class MScanTest extends AbstractScanCommandsTest {
 	@Test
 	public void testI15_1Case() throws Exception {
 		pi.exec("mscan(path=[grid(axes=('stage_x', 'stage_y'), start=(-1.5, -1.0), stop=(0.5, 1.0), count=(2, 2), snake=False)], mon=['s1MockNeXusSlit'], det=[detector('mandelbrot', 0.001, maxIterations=500, escapeRadius=10.0, columns=301, rows=241, points=100, maxRealCoordinate=1.5, maxImaginaryCoordinate=1.2, realAxisName='stage_x', imaginaryAxisName='stage_y', enableNoise=False, noiseFreeExposureTime=5.0, saveImage=True, saveSpectrum=True, saveValue=True)])");
+	}
+
+	@Test
+	public void testStepWithTimeout() throws Exception {
+		assertEquals(-1, Services.getScannableDeviceService().getScannable("stage_x").getTimeout());
+		pi.exec("mscan(step(axis='stage_x', start=300, stop=310, step=1, timeout=2))");
+		assertEquals(2, Services.getScannableDeviceService().getScannable("stage_x").getTimeout());
+		Services.getScannableDeviceService().getScannable("stage_x").setTimeout(-1);
+	}
+
+	@Test
+	public void testGridWithTimeout() throws Exception {
+		assertEquals(-1, Services.getScannableDeviceService().getScannable("xNex").getTimeout());
+		assertEquals(-1, Services.getScannableDeviceService().getScannable("yNex").getTimeout());
+		pi.exec("mscan(grid(axes=('xNex', 'yNex'), start=(0, 0), stop=(10, 10), count=(2, 2), snake=True, timeout=1), det=detector('mandelbrot', 0.001))");
+		assertEquals(1, Services.getScannableDeviceService().getScannable("xNex").getTimeout());
+		assertEquals(1, Services.getScannableDeviceService().getScannable("yNex").getTimeout());
+		Services.getScannableDeviceService().getScannable("xNex").setTimeout(-1);
+		Services.getScannableDeviceService().getScannable("yNex").setTimeout(-1);
 	}
 
 }


### PR DESCRIPTION
Allowed the 'timeout' keyword arg to be used in scanning model commands. 

This sets the timeout on the axes directly and is not actually part of the model. The timeout is persisted and if set from the mscan command stays as the timeout for that scannable. Therefore it is really better to set the timeout property in spring.