### PR TITLE
Added ability for scannables to have tolerance and less getPositions (DO NOT MERGE)

### DIFF
--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/AbstractScannable.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/AbstractScannable.java
@@ -44,6 +44,7 @@ public abstract class AbstractScannable<T> implements IScannable<T>, IScanAttrib
 
 	private T                   max;
 	private T                   min;
+	private T                   tolerance;
 	private Map<String, Object> attributes;
 	private int                 level;
 	private String              name;
@@ -235,7 +236,7 @@ public abstract class AbstractScannable<T> implements IScannable<T>, IScanAttrib
 			}
 
 			@Override
-			public void setPosition(T value, IPosition position) throws Exception {
+			public T setPosition(T value, IPosition position) throws Exception {
 				throw new Exception("Cannot set position, scannable is empty!");
 			}
 		};
@@ -269,6 +270,16 @@ public abstract class AbstractScannable<T> implements IScannable<T>, IScanAttrib
 	@Override
 	public void setTimeout(long timeout) {
 		this.timeout = timeout;
+	}
+	@Override
+	public T getTolerance() {
+		return tolerance;
+	}
+	@Override
+	public T setTolerance(T tolerance) {
+		T orig = this.tolerance;
+		this.tolerance = tolerance;
+		return orig;
 	}
 
 }

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/CountableScannable.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/CountableScannable.java
@@ -1,0 +1,87 @@
+/*-
+ *******************************************************************************
+ * Copyright (c) 2011, 2017 Diamond Light Source Ltd.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Matthew Gerring - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.scanning.api;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.scanning.api.device.IScannableDeviceService;
+import org.eclipse.scanning.api.event.core.IPublisher;
+import org.eclipse.scanning.api.scan.event.Location;
+
+/**
+ * 
+ * A scannable with the ability to record method counts.
+ * 
+ * This is primarily useful for testing and debugging it
+ * means that a dependency on Mockhito is not required 
+ * in order to count method calls.
+ * 
+ * @author Matthew Gerring
+ *
+ */
+public abstract class CountableScannable<T> extends AbstractScannable<T> {
+
+
+	private Map<String, Integer> counts = new HashMap<>();
+
+	public CountableScannable() {
+		super();
+	}
+
+	public CountableScannable(IPublisher<Location> publisher, IScannableDeviceService sservice) {
+		super(publisher, sservice);
+	}
+
+	public CountableScannable(IPublisher<Location> publisher) {
+		super(publisher);
+	}
+
+	public CountableScannable(IScannableDeviceService sservice) {
+		super(sservice);
+	}
+	
+	protected void count(StackTraceElement[] ste) {
+		String methodName = getMethodName(ste);
+		Integer count = counts.get(methodName);
+		if (count==null) count = 0;
+		count = count+1;
+		counts.put(methodName, count);
+	}
+	
+	public int getCount(String method) {
+		if (!counts.containsKey(method)) return 0;
+		return counts.get(method);
+	}
+	
+	protected static final String getMethodName ( StackTraceElement ste[] ) {  
+		   
+	    String methodName = "";  
+	    boolean flag = false;  
+	   
+	    for ( StackTraceElement s : ste ) {  
+	   
+	        if ( flag ) {  
+	   
+	            methodName = s.getMethodName();  
+	            break;  
+	        }  
+	        flag = s.getMethodName().equals( "getStackTrace" );  
+	    }  
+	    return methodName;  
+	}
+	
+	public void resetCount() {
+		counts.clear();
+	}
+
+}

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/IScannable.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/IScannable.java
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.eclipse.scanning.api;
 
-import org.eclipse.scanning.api.device.IActivatable;
 import org.eclipse.scanning.api.points.IPosition;
 
 /**
@@ -34,7 +33,10 @@ import org.eclipse.scanning.api.points.IPosition;
  * @param <T> the type of value returned by {@link #getPosition()}
  *
  */
-public interface IScannable<T> extends ILevel, INameable, ITimeoutable, IBoundable<T>, IMonitoredDevice {
+public interface IScannable<T> extends 
+						           /* A list of mostly defaulted and vanilla interfaces optionally used for scannables */
+						           ILevel, INameable, ITimeoutable, 
+						           IBoundable<T>, ITolerable<T>, IMonitoredDevice {
 	
 	/**
 	 * Returns the current position of the Scannable. Called by ConcurentScan at the end of the point. 
@@ -52,9 +54,10 @@ public interface IScannable<T> extends ILevel, INameable, ITimeoutable, IBoundab
 	 * 
 	 * @param value
 	 * @throws Exception
+	 * @return the new position attained by the device, if known. (Saves additional call to getPosition()) If not know the demand value is returned. NOTE if null is returned the system will call getPosition() again.
 	 */
-	default void setPosition(T value) throws Exception {
-		setPosition(value, null);
+	default T setPosition(T value) throws Exception {
+		return setPosition(value, null);
 	}
 
 	
@@ -64,9 +67,10 @@ public interface IScannable<T> extends ILevel, INameable, ITimeoutable, IBoundab
 	 * 
 	 * @param value that this scalar should take.
 	 * @param position if within in a scan or null if not within a scan.
+	 * @return the new position attained by the device, if known. (Saves additional call to getPosition()) If not know the demand value is returned. NOTE if null is returned the system will call getPosition() again.
 	 * @throws Exception
 	 */
-	public void setPosition(T value, IPosition position) throws Exception;
+	public T setPosition(T value, IPosition position) throws Exception;
 
 	/**
 	 * The unit is the unit in which the setPosition and getPosition values are in.

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/ITolerable.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/ITolerable.java
@@ -1,0 +1,35 @@
+package org.eclipse.scanning.api;
+
+public interface ITolerable<T> {
+
+	/**
+	 * The tolerance is a value +/- position which
+	 * when the position is still within this tolerance
+	 * means that a setPosition(...) does nothing. 
+	 * 
+	 * This principle of tolerance allows jittery motors
+	 * not to have value set when their current value is
+	 * within acceptable accuracy or tolerance.
+	 * 
+	 * @return
+	 */
+	default T getTolerance() {
+		return null;
+	}
+	
+	/**
+	 * Set the tolerance which when set will allow setPosition(...)
+	 * on the device to check if a position set is required.
+	 * 
+	 * The tolerance is a value +/- position which
+	 * when the position is still within this tolerance
+	 * means that a setPosition(...) does nothing. 
+	 *
+	 * @param toleranceValue
+	 * @return The previous value including null if tolerance is being set for the first time.
+	 */
+	default T setTolerance(T toleranceValue) {
+		throw new IllegalArgumentException("Tolerance is not implemented for "+getClass().getSimpleName());
+	}
+
+}

--- a/org.eclipse.scanning.event/src/org/eclipse/scanning/event/remote/_Scannable.java
+++ b/org.eclipse.scanning.event/src/org/eclipse/scanning/event/remote/_Scannable.java
@@ -70,7 +70,7 @@ class _Scannable<T> extends _AbstractRemoteDevice<T> implements IScannable<T>, I
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public void setPosition(T value, IPosition position) throws Exception {
+	public T setPosition(T value, IPosition position) throws Exception {
 		try {
 			// Will tell us that the value is changing by recording the time of the change 
 			addListener(); 
@@ -87,6 +87,7 @@ class _Scannable<T> extends _AbstractRemoteDevice<T> implements IScannable<T>, I
 		} catch (Exception ne) {
 			logger.error("Cannot update device info for "+info.getName(), ne);
 		}
+		return value;
 	}
 	
 

--- a/org.eclipse.scanning.example/src/org/eclipse/scanning/example/scannable/MockBeamOnMonitor.java
+++ b/org.eclipse.scanning.example/src/org/eclipse/scanning/example/scannable/MockBeamOnMonitor.java
@@ -25,14 +25,14 @@ public class MockBeamOnMonitor extends MockScannable {
 		super(string,d,i);
 	}
 
-	public void setPosition(Number position, IPosition loc) throws Exception {
+	public Number setPosition(Number position, IPosition loc) throws Exception {
 		
 		final int step = loc.getStepIndex();
 		if (step>0 && step%10==0) { // We wait
 			System.out.println("Beam is deamed to be off ");
 			throw new Exception("Cannot run scan further!");
 		}
-		super.setPosition(position, loc);
+		return super.setPosition(position, loc);
 	}
 
 }

--- a/org.eclipse.scanning.example/src/org/eclipse/scanning/example/scannable/MockCountingPositionScannable.java
+++ b/org.eclipse.scanning.example/src/org/eclipse/scanning/example/scannable/MockCountingPositionScannable.java
@@ -1,0 +1,27 @@
+package org.eclipse.scanning.example.scannable;
+
+import org.eclipse.scanning.api.points.IPosition;
+
+public class MockCountingPositionScannable extends MockScannable {
+
+	private final boolean returnPosition;
+
+	public MockCountingPositionScannable(String name, double position, boolean returnPosition) {
+    	super(name, position);
+    	this.returnPosition = returnPosition;
+	}
+
+	@Override
+	public Number setPosition(Number value, IPosition loc) throws Exception {
+        count(Thread.currentThread().getStackTrace());
+        Number ret = super.setPosition(value, loc);
+        return returnPosition ? ret : null;
+	}
+	
+
+	@Override
+	public Number getPosition() {
+        count(Thread.currentThread().getStackTrace());
+        return super.getPosition();
+	}
+}

--- a/org.eclipse.scanning.example/src/org/eclipse/scanning/example/scannable/MockNeXusScannable.java
+++ b/org.eclipse.scanning.example/src/org/eclipse/scanning/example/scannable/MockNeXusScannable.java
@@ -105,7 +105,7 @@ public class MockNeXusScannable extends MockScannable implements INexusDevice<NX
 		return nexusDelegate;
 	}	
 
-	public void setPosition(Number value, IPosition position) throws Exception {
+	public Number setPosition(Number value, IPosition position) throws Exception {
 		
 		if (value!=null) {
 			int index = position!=null ? position.getIndex(getName()) : -1;
@@ -117,13 +117,14 @@ public class MockNeXusScannable extends MockScannable implements INexusDevice<NX
 		}
 
 		if (position!=null) {
-			write(value, getPosition(), position);
+			return write(value, getPosition(), position);
 		}
+		return this.position;
 	}
 
-	private void write(Number demand, Number actual, IPosition loc) throws Exception {
+	private Number write(Number demand, Number actual, IPosition loc) throws Exception {
 		
-		if (lzValue==null) return;
+		if (lzValue==null) return actual;
 		if (actual!=null) {
 			// write actual position
 			final Dataset newActualPositionData = DatasetFactory.createFromObject(actual);
@@ -132,7 +133,7 @@ public class MockNeXusScannable extends MockScannable implements INexusDevice<NX
 			if (isWritingOn()) lzValue.setSlice(null, newActualPositionData, sliceND);
 		}
 
-		if (lzSet==null) return;
+		if (lzSet==null) return actual;
 		if (demand!=null) {
 			int index = loc.getIndex(getName());
 			if (index<0) {
@@ -145,6 +146,7 @@ public class MockNeXusScannable extends MockScannable implements INexusDevice<NX
 			final Dataset newDemandPositionData = DatasetFactory.createFromObject(demand);
 			if (isWritingOn()) lzSet.setSlice(null, newDemandPositionData, startPos, stopPos, null);
 		}
+		return actual;
 	}
 	
 	/**

--- a/org.eclipse.scanning.example/src/org/eclipse/scanning/example/scannable/MockNeXusSlit.java
+++ b/org.eclipse.scanning.example/src/org/eclipse/scanning/example/scannable/MockNeXusSlit.java
@@ -115,7 +115,7 @@ public class MockNeXusSlit extends MockScannable implements INexusDevice<NXslit>
 		return nexusDelegate;
 	}
 
-	public void setPosition(Number initialValue, IPosition position) throws Exception {
+	public Number setPosition(Number initialValue, IPosition position) throws Exception {
 		Number value = initialValue;
 
 		if (value!=null) {
@@ -130,6 +130,7 @@ public class MockNeXusSlit extends MockScannable implements INexusDevice<NXslit>
 		if (position!=null) {
 			write(value, getPosition(), position);
 		}
+		return this.position;
 	}
 
 	private void write(Number demand, Number actual, IPosition loc) throws Exception {

--- a/org.eclipse.scanning.example/src/org/eclipse/scanning/example/scannable/MockPausingMonitor.java
+++ b/org.eclipse.scanning.example/src/org/eclipse/scanning/example/scannable/MockPausingMonitor.java
@@ -27,7 +27,7 @@ public class MockPausingMonitor extends MockScannable {
 		super(string,d,i);
 	}
 
-	public void setPosition(Number position, IPosition loc) throws Exception {
+	public Number setPosition(Number position, IPosition loc) throws Exception {
 		
 		final int step = loc.getStepIndex();
 		if (step%10==0) { // We wait
@@ -35,7 +35,7 @@ public class MockPausingMonitor extends MockScannable {
 			Thread.sleep(10);
 			System.out.println("Bean current is now stable again... ");
 		}
-		super.setPosition(position, loc);
+		return super.setPosition(position, loc);
 	}
 
 }

--- a/org.eclipse.scanning.example/src/org/eclipse/scanning/example/scannable/MockScannable.java
+++ b/org.eclipse.scanning.example/src/org/eclipse/scanning/example/scannable/MockScannable.java
@@ -24,7 +24,7 @@ import org.eclipse.january.dataset.DatasetFactory;
 import org.eclipse.january.dataset.IDataset;
 import org.eclipse.january.dataset.LazyWriteableDataset;
 import org.eclipse.january.dataset.SliceND;
-import org.eclipse.scanning.api.AbstractScannable;
+import org.eclipse.scanning.api.CountableScannable;
 import org.eclipse.scanning.api.IConfigurable;
 import org.eclipse.scanning.api.ITerminatable;
 import org.eclipse.scanning.api.annotation.scan.ScanFinally;
@@ -34,7 +34,7 @@ import org.eclipse.scanning.api.points.Scalar;
 import org.eclipse.scanning.api.scan.ScanningException;
 import org.eclipse.scanning.example.Services;
 
-public class MockScannable extends AbstractScannable<Number> implements IConfigurable<MockScannableModel>, ITerminatable {
+public class MockScannable extends CountableScannable<Number> implements IConfigurable<MockScannableModel>, ITerminatable {
 
 	protected Number  position = 0d;
 	private boolean requireSleep=true;
@@ -135,20 +135,20 @@ public class MockScannable extends AbstractScannable<Number> implements IConfigu
 	public Number getPosition() {
 		return position;
 	}
-	public void setPosition(Number position) throws Exception {
-		setPosition(position, null);
+	public Number setPosition(Number position) throws Exception {
+		return setPosition(position, null);
 	}
 	
 	public void setInitialPosition(Number position) {
 		this.position = position;
 	}
 	
-	public void setPosition(Number value, IPosition loc) throws Exception {
+	public Number setPosition(Number value, IPosition loc) throws Exception {
 		
 		int index = loc!=null ? loc.getIndex(getName()) : -1;
 		double val = value!=null ? value.doubleValue() : Double.NaN;
 		boolean ok = delegate.firePositionWillPerform(new Scalar(getName(), index, val));
-		if (!ok) return;
+		if (!ok) return this.position;
 		
 		if (value!=null && position!=null) {
 			long waitTime = Math.abs(Math.round((val-this.position.doubleValue()))*100);
@@ -184,7 +184,7 @@ public class MockScannable extends AbstractScannable<Number> implements IConfigu
 		}
 		
 		delegate.firePositionPerformed(-1, new Scalar(getName(), index, val));
-		
+		return this.position;
 	}
 	
 	private TerminationPreference terminate;

--- a/org.eclipse.scanning.example/src/org/eclipse/scanning/example/scannable/MockStringNexusScannable.java
+++ b/org.eclipse.scanning.example/src/org/eclipse/scanning/example/scannable/MockStringNexusScannable.java
@@ -51,10 +51,11 @@ public class MockStringNexusScannable extends MockStringScannable implements INe
 		return new NexusObjectWrapper<>(getName(), positioner, NXpositioner.NX_VALUE);
 	}
 	
-	public void setPosition(String value, IPosition position) throws Exception {
+	public String setPosition(String value, IPosition position) throws Exception {
 		if (position != null) {
 			write(value, getPosition(), position);
 		}
+		return value;
 	}
 	
 	private void write(String demand, String actual, IPosition pos) throws Exception {

--- a/org.eclipse.scanning.example/src/org/eclipse/scanning/example/scannable/MockStringScannable.java
+++ b/org.eclipse.scanning.example/src/org/eclipse/scanning/example/scannable/MockStringScannable.java
@@ -33,9 +33,10 @@ public class MockStringScannable extends AbstractScannable<String> implements IN
 	}
 
 	@Override
-	public void setPosition(String value, IPosition position) throws Exception {
+	public String setPosition(String value, IPosition position) throws Exception {
 		this.value = value;
 		delegate.firePositionChanged(getLevel(), new Scalar<String>(getName(), -1, value));
+		return value;
 	}
 
 	@Override

--- a/org.eclipse.scanning.example/src/org/eclipse/scanning/example/scannable/MockTopupScannable.java
+++ b/org.eclipse.scanning.example/src/org/eclipse/scanning/example/scannable/MockTopupScannable.java
@@ -78,12 +78,13 @@ public class MockTopupScannable extends MockScannable implements IDisconnectable
 		return !isRunning;
 	}
 
-	public void setPosition(Number position) throws Exception {
-		setPosition(position, null);
+	public Number setPosition(Number position) throws Exception {
+		return setPosition(position, null);
 	}
-	public void setPosition(Number position, IPosition loc) throws Exception {
+	public Number setPosition(Number position, IPosition loc) throws Exception {
 		this.position = position;
 	    delegate.firePositionChanged(getLevel(), new Scalar(getName(), -1, position));
+	    return this.position;
 	}
 	
 	/**

--- a/org.eclipse.scanning.example/src/org/eclipse/scanning/example/scannable/composite/CompositeNexusScannable.java
+++ b/org.eclipse.scanning.example/src/org/eclipse/scanning/example/scannable/composite/CompositeNexusScannable.java
@@ -39,7 +39,7 @@ public class CompositeNexusScannable<T, N extends NXobject> extends AbstractScan
 	}
 
 	@Override
-	public void setPosition(T value, IPosition position) throws Exception {
+	public T setPosition(T value, IPosition position) throws Exception {
 		throw new UnsupportedOperationException("A CompositeNexusScannable should only be used as a per-scan monitor");
 	}
 	

--- a/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/nexus/SolsticeScanMonitor.java
+++ b/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/nexus/SolsticeScanMonitor.java
@@ -252,8 +252,8 @@ public class SolsticeScanMonitor extends AbstractScannable<Object> implements IN
 	}
 
 	@Override
-	public void setPosition(Object value, IPosition position) {
-		writePosition(position);
+	public Object setPosition(Object value, IPosition position) {
+		return writePosition(position);
 	}
 
 	/**
@@ -303,7 +303,7 @@ public class SolsticeScanMonitor extends AbstractScannable<Object> implements IN
 	 * @param position
 	 * @throws Exception
 	 */
-	private void writePosition(IPosition position) {
+	private Object writePosition(IPosition position) {
 		if (!malcolmScan) {
 			IScanSlice rslice = IScanRankService.getScanRankService().createScanSlice(position);
 			SliceND sliceND = new SliceND(uniqueKeys.getShape(), uniqueKeys.getMaxShape(), rslice.getStart(), rslice.getStop(), rslice.getStep());
@@ -314,7 +314,9 @@ public class SolsticeScanMonitor extends AbstractScannable<Object> implements IN
 			} catch (DatasetException e) {
 				logger.error("Could not write unique key");
 			}
+			return newActualPosition;
 		}
+		return null;
 	}
 
 }

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/annot/CountingDevice.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/annot/CountingDevice.java
@@ -11,10 +11,7 @@
  *******************************************************************************/
 package org.eclipse.scanning.test.annot;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.eclipse.scanning.api.AbstractScannable;
+import org.eclipse.scanning.api.CountableScannable;
 import org.eclipse.scanning.api.annotation.scan.LevelStart;
 import org.eclipse.scanning.api.annotation.scan.PostConfigure;
 import org.eclipse.scanning.api.annotation.scan.PreConfigure;
@@ -28,10 +25,9 @@ import org.eclipse.scanning.api.scan.ScanInformation;
  * Could use Mockito but always causes compilation issues
  *
  */
-public class CountingDevice extends AbstractScannable<Double> {
+public class CountingDevice extends CountableScannable<Double> {
 	
 	protected Double value;
-	protected Map<String, Integer> counts = new HashMap<>();
 	
 	public CountingDevice() {
 		
@@ -72,38 +68,9 @@ public class CountingDevice extends AbstractScannable<Double> {
 		return value;
 	}
 	@Override
-	public void setPosition(Double value, IPosition position) throws Exception {
+	public Double setPosition(Double value, IPosition position) throws Exception {
 		this.value = value;
-	}
-	
-	protected void count(StackTraceElement[] ste) {
-		String methodName = getMethodName(ste);
-		Integer count = counts.get(methodName);
-		if (count==null) count = 0;
-		count = count+1;
-		counts.put(methodName, count);
-	}
-	
-	public int getCount(String method) {
-		if (!counts.containsKey(method)) return 0;
-		return counts.get(method);
-	}
-	
-	protected static final String getMethodName ( StackTraceElement ste[] ) {  
-		   
-	    String methodName = "";  
-	    boolean flag = false;  
-	   
-	    for ( StackTraceElement s : ste ) {  
-	   
-	        if ( flag ) {  
-	   
-	            methodName = s.getMethodName();  
-	            break;  
-	        }  
-	        flag = s.getMethodName().equals( "getStackTrace" );  
-	    }  
-	    return methodName;  
+		return value;
 	}
 
 }

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/AnnotationScanTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/AnnotationScanTest.java
@@ -183,8 +183,8 @@ public class AnnotationScanTest extends NexusTest {
 		}
 
 		@Override
-		public void setPosition(Object value, IPosition position) throws Exception {
-			// do nothing
+		public Object setPosition(Object value, IPosition position) throws Exception {
+			return null; // No position set
 		}
 
 		@Override

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/SetPositionTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/SetPositionTest.java
@@ -1,0 +1,89 @@
+package org.eclipse.scanning.test.scan;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.scanning.api.CountableScannable;
+import org.eclipse.scanning.api.device.IRunnableDeviceService;
+import org.eclipse.scanning.api.device.IScannableDeviceService;
+import org.eclipse.scanning.api.points.MapPosition;
+import org.eclipse.scanning.api.scan.event.IPositioner;
+import org.eclipse.scanning.example.scannable.MockCountingPositionScannable;
+import org.eclipse.scanning.example.scannable.MockScannableConnector;
+import org.eclipse.scanning.sequencer.RunnableDeviceServiceImpl;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SetPositionTest {
+
+	private static IRunnableDeviceService  dservice;
+	private static IScannableDeviceService connector;
+	private static CountableScannable<Number> cpsGood;
+	private static CountableScannable<Number> cpsBad;
+
+	@BeforeClass
+	public static void before() {
+		MockScannableConnector msc = new MockScannableConnector(null);
+		cpsGood = new MockCountingPositionScannable("cpsGood", 10, true);
+		cpsBad  = new MockCountingPositionScannable("cpsBad", 10, false);
+		msc.register(cpsGood);
+		msc.register(cpsBad);
+		
+		connector = msc;
+		dservice  = new RunnableDeviceServiceImpl(connector);
+	}
+	
+	@After
+	public void reset() throws Exception {
+		cpsGood.setPosition(10, null);
+		cpsBad.setPosition(10, null);
+		cpsGood.resetCount();
+		cpsBad.resetCount();
+	}
+	
+	@Test
+	public void testMoveNoExtraGetPosition() throws Exception {
+		
+		// Something without 
+		IPositioner     pos    = dservice.createPositioner();
+        pos.setPosition(new MapPosition("cpsGood:0:20"));
+        
+        assertEquals(0, cpsGood.getCount("getPosition"));
+        assertEquals(20d, cpsGood.getPosition().doubleValue(), 0.0000001);
+        assertEquals(1, cpsGood.getCount("setPosition"));
+        assertEquals(1, cpsGood.getCount("getPosition"));
+	}
+
+	@Test
+	public void testMoveExtraGetPosition() throws Exception {
+		
+		// Something without 
+		IPositioner     pos    = dservice.createPositioner();
+        pos.setPosition(new MapPosition("cpsBad:0:20"));
+        
+        assertEquals(1, cpsBad.getCount("getPosition"));
+        assertEquals(20d, cpsBad.getPosition().doubleValue(), 0.0000001);
+        assertEquals(1, cpsBad.getCount("setPosition"));
+        assertEquals(2, cpsBad.getCount("getPosition"));
+	}
+
+
+	@Test
+	public void testMoveTwoThingsTogether() throws Exception {
+		
+		// Something without 
+		IPositioner     pos    = dservice.createPositioner();
+        pos.setPosition(new MapPosition("cpsBad:0:20, cpsGood:0:20"));
+        
+        assertEquals(0, cpsGood.getCount("getPosition"));
+        assertEquals(20d, cpsGood.getPosition().doubleValue(), 0.0000001);
+        assertEquals(1, cpsGood.getCount("setPosition"));
+        assertEquals(1, cpsGood.getCount("getPosition"));
+
+        assertEquals(1, cpsBad.getCount("getPosition"));
+        assertEquals(20d, cpsBad.getPosition().doubleValue(), 0.0000001);
+        assertEquals(1, cpsBad.getCount("setPosition"));
+        assertEquals(2, cpsBad.getCount("getPosition"));
+	}
+
+}

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/Suite.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/Suite.java
@@ -19,6 +19,8 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({
 
 	ScanTest.class,
+	ToleranceTest.class,
+    SetPositionTest.class,
 	SeekTest.class,
 	ParserTest.class,
 	BenchmarkScanTest.class,

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/ToleranceTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/ToleranceTest.java
@@ -1,0 +1,111 @@
+package org.eclipse.scanning.test.scan;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.scanning.api.IScannable;
+import org.eclipse.scanning.api.device.IRunnableDeviceService;
+import org.eclipse.scanning.api.device.IScannableDeviceService;
+import org.eclipse.scanning.api.points.MapPosition;
+import org.eclipse.scanning.api.scan.event.IPositioner;
+import org.eclipse.scanning.example.scannable.MockScannableConnector;
+import org.eclipse.scanning.sequencer.RunnableDeviceServiceImpl;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ToleranceTest {
+
+	private static IRunnableDeviceService  dservice;
+	private static IScannableDeviceService connector;
+
+	@BeforeClass
+	public static void before() {
+		connector = new MockScannableConnector(null);
+		dservice  = new RunnableDeviceServiceImpl(connector);
+	}
+	
+	@Test
+	public void testMoveNoTolerance() throws Exception {
+		
+		// Something without 
+		IScannable<Double> a   = connector.getScannable("a");
+		IPositioner     pos    = dservice.createPositioner();
+        pos.setPosition(new MapPosition("a:0:20"));
+        
+        assertEquals(new Double(20d), (Double)a.getPosition());
+	}
+	
+	@Test
+	public void testMoveWithTolerance() throws Exception {
+		
+		// Something without 
+		IScannable<Double> a   = connector.getScannable("a");
+		IPositioner     pos    = dservice.createPositioner();
+        pos.setPosition(new MapPosition("a:0:20"));
+        
+		a.setTolerance(1d);
+        pos.setPosition(new MapPosition("a:0:20.5"));
+		
+        assertEquals(new Double(20d), (Double)a.getPosition());
+	}
+
+	@Test
+	public void testMoveEdgeOfTolerance() throws Exception {
+		
+		// Something without 
+		IScannable<Double> a   = connector.getScannable("a");
+		IPositioner     pos    = dservice.createPositioner();
+        pos.setPosition(new MapPosition("a:0:20"));
+        
+		a.setTolerance(1d);
+        pos.setPosition(new MapPosition("a:0:21.0"));
+		
+        assertEquals(new Double(21d), (Double)a.getPosition());
+	}
+	
+	@Test
+	public void testOutsideTolerance() throws Exception {
+		
+		// Something without 
+		IScannable<Double> a   = connector.getScannable("a");
+		IPositioner     pos    = dservice.createPositioner();
+        pos.setPosition(new MapPosition("a:0:20"));
+        
+		a.setTolerance(1d);
+        pos.setPosition(new MapPosition("a:0:22.4"));
+		
+        assertEquals(new Double(22.4), (Double)a.getPosition());
+	}
+
+	@Test
+	public void testChangeTolerance() throws Exception {
+		
+		// Something without 
+		IScannable<Double> a   = connector.getScannable("a");
+		IPositioner     pos    = dservice.createPositioner();
+        pos.setPosition(new MapPosition("a:0:20"));
+        
+		a.setTolerance(1d);
+        pos.setPosition(new MapPosition("a:0:20.5"));
+        assertEquals(new Double(20d), (Double)a.getPosition());
+		a.setTolerance(0.5d);
+        pos.setPosition(new MapPosition("a:0:20.5"));
+        assertEquals(new Double(20.5d), (Double)a.getPosition());
+	}
+	
+	@Test
+	public void testSetToleranceNull() throws Exception {
+		
+		// Something without 
+		IScannable<Double> a   = connector.getScannable("a");
+		IPositioner     pos    = dservice.createPositioner();
+        pos.setPosition(new MapPosition("a:0:20"));
+        
+		a.setTolerance(1d);
+        pos.setPosition(new MapPosition("a:0:20.5"));
+        assertEquals(new Double(20d), (Double)a.getPosition());
+		a.setTolerance(null);
+        pos.setPosition(new MapPosition("a:0:20.5"));
+        assertEquals(new Double(20.5d), (Double)a.getPosition());
+	}
+
+}


### PR DESCRIPTION
In order to speed up Solstice motor moving (which has been reported as a real issue on more than one beamline) I intend to make two changes to it:
1.	Introduce a tolerance to IScannable
2.	Return a value from setPosition(…) which stops getPosition being called again

•	If a tolerance is non-null the position will be checked and the motor not moved. This still does a getPosition() call.
•	A IScannable may optionally return a position when it is moved which stops an additional getPosition() being called by the ExecutorService running the multi-threaded move.

[Method changes proposed to IScannable interface.]

The change will be done to mock IScannables and tests written to check the position calls are reduced. The class ScannableNexusWrapper which bridges GDA8 Scannables to Solstice will be changed. It already rereads value so it could return that and increase efficiency.

I don’t understand the all the various use cases for GDA8 Scannables and this might be a ‘solved’ issue or it might not be an issue with 8 scanning algorithms. Therefore anyone that knows more please help out. The change has no effect on 8 scanning at all.

