### PR TITLE
Modifications for defining number of threads/cores to run

### DIFF
--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/mock/MockOperationContextImpl.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/mock/MockOperationContextImpl.java
@@ -41,6 +41,7 @@ class MockOperationContextImpl implements IOperationContext {
 	// And
 	private SliceND slicing;
 	private int[] dataDimensions;
+	private int numberOfCores = 1;
 	
 	// May be null
 	private IMonitor             monitor;
@@ -251,6 +252,12 @@ class MockOperationContextImpl implements IOperationContext {
 	public void setPoolSize(int slugCount) {
 		this.poolSize = slugCount;
 	}
+	public int getNumberOfCores() {
+		return numberOfCores;
+	}
+	public void setNumberOfCores(int numberOfCores) {
+		this.numberOfCores = numberOfCores;
+	}
 
 	@Override
 	public int[] getDataDimensions() {
@@ -270,5 +277,4 @@ class MockOperationContextImpl implements IOperationContext {
 	public ILiveOperationInfo getLiveInfo() {
 		return liveInfo;
 	}
-
 }

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/mock/MockSeriesRunner.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/mock/MockSeriesRunner.java
@@ -105,7 +105,7 @@ public class MockSeriesRunner implements IOperationRunner {
 		if (context.getExecutionType()==ExecutionType.SERIES) {
 			Slicer.visit(iterator,sv);
 		} else if (context.getExecutionType()==ExecutionType.PARALLEL) {
-			Slicer.visitParallel(iterator,sv);
+			Slicer.visitParallel(iterator,sv,1);
 		} else {
 			throw new OperationException(context.getSeries()[0], "The edges are needed to execute a graph using ptolemy!");
 		}


### PR DESCRIPTION
These tests also implement the IOperationContext class from DAWN and so also needed to be updated accordingly

Signed-off-by: Tim Snow <tim.snow@diamond.ac.uk>