### PR TITLE
Updates to Queue Atoms/Beans

### DIFF
--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/queues/beans/MonitorAtom.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/queues/beans/MonitorAtom.java
@@ -44,12 +44,10 @@ public class MonitorAtom extends QueueAtom {
 	 * Constructor with arguments required to fully configure this atom
 	 * 
 	 * @param monShrtNm String short name used within the QueueBeanFactory
-	 * @param monName - name for atom
 	 * @param dev - name of monitor
 	 */
-	public MonitorAtom(String monShrtNm, String monName, String dev) {
+	public MonitorAtom(String monShrtNm, String dev) {
 		super();
-		setName(monName);
 		setShortName(monShrtNm);
 		monitor = dev;
 	}

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/queues/beans/MonitorAtom.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/queues/beans/MonitorAtom.java
@@ -15,9 +15,9 @@ import org.eclipse.scanning.api.event.queues.IQueueService;
 
 /**
  * MonitorAtom is a type of {@link QueueAtom} which may be processed within an 
- * active-queue of an {@link IQueueService}. It contains name of a monitor 
- * which the current value needs to be recorded at a particular point in an 
- * experiment.
+ * active-queue of an {@link IQueueService}. It contains name of a monitor the
+ * current value of which will be on execution as a dataset within a file 
+ * (located at filePath).
  * 
  * @author Michael Wharmby
  *
@@ -42,24 +42,16 @@ public class MonitorAtom extends QueueAtom {
 	
 	/**
 	 * Constructor with arguments required to fully configure this atom
+	 * 
+	 * @param monShrtNm String short name used within the QueueBeanFactory
 	 * @param monName - name for atom
 	 * @param dev - name of monitor
 	 */
-	public MonitorAtom(String monName, String dev, long time) {
+	public MonitorAtom(String monShrtNm, String monName, String dev) {
 		super();
 		setName(monName);
+		setShortName(monShrtNm);
 		monitor = dev;
-		runTime = time;
-	}
-
-	@Override
-	public long getRunTime() {
-		return runTime;
-	}
-
-	@Override
-	public void setRunTime(long runTime) {
-		this.runTime = runTime;
 	}
 
 	/**
@@ -133,7 +125,13 @@ public class MonitorAtom extends QueueAtom {
 
 	@Override
 	public String toString() {
-		return "MonitorAtom [monitor=" + monitor + ", filePath=" + filePath + ", dataset=" + dataset + "]";
+		String clazzName = this.getClass().getSimpleName();
+		return clazzName + " [name=" + name + "(shortName=" + shortName + "), monitor=" + monitor
+				+ ", filePath=" + filePath + ", dataset=" + dataset + ", status=" + status
+				+ ", message=" + message + ", percentComplete=" + percentComplete + ", previousStatus=" 
+				+ previousStatus + ", runTime=" + runTime + ", userName=" + userName + ", hostName=" 
+				+ hostName + ", beamline="+ beamline + ", submissionTime=" + submissionTime 
+				+ ", properties=" + getProperties() + ", id=" + getUniqueId() + "]";
 	}
 	
 }

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/queues/beans/PositionerAtom.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/queues/beans/PositionerAtom.java
@@ -46,13 +46,11 @@ public class PositionerAtom extends QueueAtom {
 	 * Constructor with required arguments to configure one positioner.
 	 * 
 	 * @param posShrtNm String short name used within the QueueBeanFactory
-	 * @param posName String automatically/user supplied name for this atom. 
 	 * @param positionDev String name of positioner to set.
 	 * @param target Object representing the target position.
 	 */
-	public PositionerAtom(String posShrtNm, String posName, String positionDev, Object target) {
+	public PositionerAtom(String posShrtNm, String positionDev, Object target) {
 		super();
-		setName(posName);
 		setShortName(posShrtNm);
 		positionerConfig = new LinkedHashMap<String, Object>();
 		positionerConfig.put(positionDev, target);
@@ -62,13 +60,11 @@ public class PositionerAtom extends QueueAtom {
 	 * Constructor with required arguments for multiple motor positions.
 	 * 
 	 * @param posShrtNm String short name used within the QueueBeanFactory
-	 * @param posName String automatically/user supplied name for this atom.
 	 * @param positionerConfig Map of form String positionerDev name Object 
 	 *                         target position.
 	 */
-	public PositionerAtom(String posShrtNm, String posName, Map<String, Object> positionerConfig) {
+	public PositionerAtom(String posShrtNm, Map<String, Object> positionerConfig) {
 		super();
-		setName(posName);
 		setShortName(posShrtNm);
 		this.positionerConfig = positionerConfig;
 	}

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/queues/beans/PositionerAtom.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/queues/beans/PositionerAtom.java
@@ -45,14 +45,15 @@ public class PositionerAtom extends QueueAtom {
 	/**
 	 * Constructor with required arguments to configure one positioner.
 	 * 
+	 * @param posShrtNm String short name used within the QueueBeanFactory
 	 * @param posName String automatically/user supplied name for this atom. 
 	 * @param positionDev String name of positioner to set.
 	 * @param target Object representing the target position.
 	 */
-	public PositionerAtom(String posName, String positionDev, Object target) {
+	public PositionerAtom(String posShrtNm, String posName, String positionDev, Object target) {
 		super();
 		setName(posName);
-		
+		setShortName(posShrtNm);
 		positionerConfig = new LinkedHashMap<String, Object>();
 		positionerConfig.put(positionDev, target);
 	}
@@ -60,13 +61,15 @@ public class PositionerAtom extends QueueAtom {
 	/**
 	 * Constructor with required arguments for multiple motor positions.
 	 * 
+	 * @param posShrtNm String short name used within the QueueBeanFactory
 	 * @param posName String automatically/user supplied name for this atom.
 	 * @param positionerConfig Map of form String positionerDev name Object 
 	 *                         target position.
 	 */
-	public PositionerAtom(String posName, Map<String, Object> positionerConfig) {
+	public PositionerAtom(String posShrtNm, String posName, Map<String, Object> positionerConfig) {
 		super();
 		setName(posName);
+		setShortName(posShrtNm);
 		this.positionerConfig = positionerConfig;
 	}
 	
@@ -164,16 +167,19 @@ public class PositionerAtom extends QueueAtom {
 	
 	@Override
 	public String toString() {
+		String clazzName = this.getClass().getSimpleName();
+		
 		String positConf = "{";
 		for (Map.Entry<String, Object> poserCfg : positionerConfig.entrySet()) {
 			positConf = positConf+poserCfg.getKey()+" : "+poserCfg.getValue()+", ";
 		}
 		positConf = positConf.replaceAll(", $", "}"); //Replace trailing ", "
 		
-		return "PositionerAtom [name=" + name + ", positionerConfig=" + positConf +", status=" + status 
-				+", message=" + message + ", percentComplete=" + percentComplete + ", previousStatus=" 
-				+ previousStatus + ", runTime=" + runTime + ", userName=" + userName+ ", hostName=" 
-				+ hostName + ", beamline="+ beamline + ", submissionTime=" + submissionTime + "]";
+		return clazzName + " [name=" + name + " (shortName="+shortName+"), positionerConfig=" + positConf 
+				+ ", status=" + status + ", message=" + message + ", percentComplete=" + percentComplete 
+				+ ", previousStatus=" + previousStatus + ", runTime=" + runTime + ", userName=" + userName 
+				+ ", hostName=" + hostName + ", beamline="+ beamline + ", submissionTime=" + submissionTime 
+				+ ", properties=" + getProperties() + ", id=" + getUniqueId() + "]";
 	}
 
 }

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/queues/beans/Queueable.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/queues/beans/Queueable.java
@@ -31,6 +31,7 @@ public abstract class Queueable extends StatusBean {
 	
 	protected long runTime;
 	protected String beamline;
+	protected String shortName;
 
 	protected Queueable() {
 		super();
@@ -54,17 +55,28 @@ public abstract class Queueable extends StatusBean {
 		this.runTime = runTime;
 	}
 
+	public String getShortName() {
+		return shortName;
+	}
+
+	public void setShortName(String shortName) {
+		this.shortName = shortName;
+	}
+
 	public void merge(Queueable with) {
 		super.merge(with);
 		this.runTime = with.runTime;
 		this.beamline = with.beamline;
+		this.shortName = with.shortName;
 	}
 
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = super.hashCode();
+		result = prime * result + ((beamline == null) ? 0 : beamline.hashCode());
 		result = prime * result + (int) (runTime ^ (runTime >>> 32));
+		result = prime * result + ((shortName == null) ? 0 : shortName.hashCode());
 		return result;
 	}
 
@@ -77,7 +89,17 @@ public abstract class Queueable extends StatusBean {
 		if (getClass() != obj.getClass())
 			return false;
 		Queueable other = (Queueable) obj;
+		if (beamline == null) {
+			if (other.beamline != null)
+				return false;
+		} else if (!beamline.equals(other.beamline))
+			return false;
 		if (runTime != other.runTime)
+			return false;
+		if (shortName == null) {
+			if (other.shortName != null)
+				return false;
+		} else if (!shortName.equals(other.shortName))
 			return false;
 		return true;
 	}
@@ -85,12 +107,11 @@ public abstract class Queueable extends StatusBean {
 	@Override
 	public String toString() {
 		String clazzName = this.getClass().getSimpleName();
-		return clazzName + "[previousStatus=" + previousStatus + ", status="
-				+ status + ", name=" + name + ", message=" + message
-				+ ", percentComplete=" + percentComplete + ", userName="
-				+ userName + ", hostName=" + hostName + ", submissionTime=" 
-				+ submissionTime + ", properties=" + getProperties()
-		        + ", id=" + getUniqueId() + "]";
+		return clazzName + " [name=" + name +" (shortname=" + shortName + "), status=" + status 
+				+ ", message=" + message + ", percentComplete=" + percentComplete
+				+ ", previousStatus=" + previousStatus + ", runTime=" + runTime + ", userName="
+				+ userName + ", hostName=" + hostName + ", beamline="+ beamline + ", submissionTime="
+				+ submissionTime + ", properties=" + getProperties() + ", id=" + getUniqueId() + "]";
 	}
 
 }

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/queues/beans/ScanAtom.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/queues/beans/ScanAtom.java
@@ -57,14 +57,16 @@ public class ScanAtom extends QueueAtom implements IHasChildQueue {
 	 * Constructor with required arguments to configure a scan of positions 
 	 * using only detectors to collect data.
 	 * 
+	 * @param scShrtNm String short name used within the QueueBeanFactory
 	 * @param scName String name of scan
 	 * @param pMods List<IScanPathModel> describing the motion during the scan.
 	 * @param dMods Map<String,IDetectorModel> containing the detector 
 	 *              configuration for the scan.
 	 */
-	public ScanAtom(String scName, List<IScanPathModel> pMods, Map<String,Object> dMods) {
+	public ScanAtom(String scShrtNm, String scName, List<IScanPathModel> pMods, Map<String,Object> dMods) {
 		super();
 		setName(scName);
+		setShortName(scShrtNm);
 		pathModels = pMods;
 		detectorModels = dMods;
 	}
@@ -73,14 +75,15 @@ public class ScanAtom extends QueueAtom implements IHasChildQueue {
 	 * Constructor with required arguments to configure a scan of positions 
 	 * using both detectors and monitors to collect data.
 	 * 
+	 * @param scShrtNm String short name used within the QueueBeanFactory
 	 * @param scName String name of scan
 	 * @param pMods List<IScanPathModel> describing the motion during the scan.
 	 * @param dMods Map<String,IDetectorModel> containing the detector 
 	 *              configuration for the scan.
 	 * @param mons List<String> names of monitors to use during scan.
 	 */
-	public ScanAtom(String scName, List<IScanPathModel> pMods, Map<String,Object> dMods, Collection<String> mons) {
-		this(scName, pMods, dMods);
+	public ScanAtom(String scShrtNm, String scName, List<IScanPathModel> pMods, Map<String,Object> dMods, Collection<String> mons) {
+		this(scShrtNm, scName, pMods, dMods);
 		monitors = mons;
 	}
 

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/queues/beans/ScanAtom.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/queues/beans/ScanAtom.java
@@ -15,9 +15,10 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.scanning.api.device.models.IDetectorModel;
 import org.eclipse.scanning.api.event.queues.IQueueService;
 import org.eclipse.scanning.api.event.scan.ScanBean;
+import org.eclipse.scanning.api.event.scan.ScanRequest;
+import org.eclipse.scanning.api.points.models.CompoundModel;
 import org.eclipse.scanning.api.points.models.IScanPathModel;
 
 /**
@@ -36,10 +37,8 @@ public class ScanAtom extends QueueAtom implements IHasChildQueue {
 	 */
 	private static final long serialVersionUID = 20161021L;
 	
-	private List<IScanPathModel> pathModels;
-	private Collection<String> monitors;
-	private Map<String,Object> detectorModels;
-//	private IProcess perPointProcess;//TODO
+	private ScanRequest<?> scanReq;
+	
 	private String queueMessage;
 	
 	private String scanSubmitQueueName;
@@ -54,21 +53,34 @@ public class ScanAtom extends QueueAtom implements IHasChildQueue {
 	}
 	
 	/**
+	 * Constructor which allows specification of a scan using the full API of 
+	 * the {@link ScanRequest}.
+	 * 
+	 * @param scShrtNm String short name used within the QueueBeanFactory
+	 * @param scanReq {@link ScanRequest} describing the complete scan
+	 */
+	public ScanAtom(String scShrtNm, ScanRequest<?> scanReq) {
+		super();
+		setShortName(scShrtNm);
+		setScanReq(scanReq);
+	}
+	
+	/**
 	 * Constructor with required arguments to configure a scan of positions 
 	 * using only detectors to collect data.
 	 * 
 	 * @param scShrtNm String short name used within the QueueBeanFactory
-	 * @param scName String name of scan
-	 * @param pMods List<IScanPathModel> describing the motion during the scan.
-	 * @param dMods Map<String,IDetectorModel> containing the detector 
-	 *              configuration for the scan.
+	 * @param pMods List<IScanPathModel> describing the motion during the scan
+	 * @param dMods Map<String,Object> containing the detector configuration 
+	 *        for the scan (get these by calling 
+	 *        IRunnableDeviceService.getRunnableDevice(detector_name)
 	 */
-	public ScanAtom(String scShrtNm, String scName, List<IScanPathModel> pMods, Map<String,Object> dMods) {
+	public ScanAtom(String scShrtNm, List<IScanPathModel> pMods, Map<String,Object> dMods) {
 		super();
-		setName(scName);
 		setShortName(scShrtNm);
-		pathModels = pMods;
-		detectorModels = dMods;
+		scanReq = new ScanRequest<>();
+		scanReq.setCompoundModel(new CompoundModel<>(pMods));
+		scanReq.setDetectors(dMods);
 	}
 	
 	/**
@@ -76,135 +88,25 @@ public class ScanAtom extends QueueAtom implements IHasChildQueue {
 	 * using both detectors and monitors to collect data.
 	 * 
 	 * @param scShrtNm String short name used within the QueueBeanFactory
-	 * @param scName String name of scan
-	 * @param pMods List<IScanPathModel> describing the motion during the scan.
-	 * @param dMods Map<String,IDetectorModel> containing the detector 
-	 *              configuration for the scan.
-	 * @param mons List<String> names of monitors to use during scan.
+	 * @param pMods List<IScanPathModel> describing the motion during the scan
+	 * @param dMods Map<String,Object> containing the detector configuration 
+	 *        for the scan (get these by calling 
+	 *        IRunnableDeviceService.getRunnableDevice(detector_name)
+	 * @param mons List<String> names of monitors to use during scan
 	 */
-	public ScanAtom(String scShrtNm, String scName, List<IScanPathModel> pMods, Map<String,Object> dMods, Collection<String> mons) {
-		this(scShrtNm, scName, pMods, dMods);
-		monitors = mons;
+	public ScanAtom(String scShrtNm, List<IScanPathModel> pMods, Map<String,Object> dMods, Collection<String> mons) {
+		this(scShrtNm, pMods, dMods);
+		scanReq.setMonitorNames(mons);
+	}
+	
+	public ScanRequest<?> getScanReq() {
+		return scanReq;
 	}
 
-	/**
-	 * Get the collection of models describing the motions during the scan.
-	 * 
-	 * @return Collection<IScanPathModel> models of motor moves.
-	 */
-	public List<IScanPathModel> getPathModels() {
-		return pathModels;
+	public void setScanReq(ScanRequest<?> scanReq) {
+		this.scanReq = scanReq;
 	}
 
-	/**
-	 * Change the collection of models describing the motor moves during scan.
-	 * 
-	 * @param pathModels Collection<IScanPathModel> models of motor moves.
-	 */
-	public void setPathModels(List<IScanPathModel> pathModels) {
-		this.pathModels = pathModels;
-	}
-	
-	/**
-	 * Add another motor movement model to the scan.
-	 * 
-	 * @param pathModel IScanPathModel model of motion for the scan.
-	 */
-	public void addPathModel(IScanPathModel pathModel) {
-		pathModels.add(pathModel);
-	}
-	
-	/**
-	 * Remove an existing motor movement model from the scan.
-	 * 
-	 * @param pathModel IScanPathModel to be removed from the scan.
-	 */
-	public void removePathModel(IScanPathModel pathModel) {
-		pathModels.remove(pathModel);
-	}
-
-	/**
-	 * Return the monitors for which values will be recorded during the scan.
-	 * 
-	 * @return Collection<String> monitor names which will be polled during 
-	 *         scan.
-	 */
-	public Collection<String> getMonitors() {
-		return monitors;
-	}
-
-	/**
-	 * Change the collection of monitors with values recorded during the scan.
-	 * 
-	 * @param monitors Collection<String> monitor names which will be polled 
-	 *                 during scan.
-	 */
-	public void setMonitors(Collection<String> monitors) {
-		this.monitors = monitors;
-	}
-	
-	/**
-	 * Add a monitor to the collection of monitors to be polled during the scan.
-	 *  
-	 * @param monitor String name of monitor to be added.
-	 */
-	public void addMonitor(String monitor) {
-		monitors.add(monitor);
-	}
-	
-	/**
-	 * Remove a monitor from the collection of monitors to be polled during the
-	 * scan.
-	 *  
-	 * @param monitor String name of monitor to be removed.
-	 */
-	public void removeMonitor(String monitor) {
-		monitors.remove(monitor);
-	}
-
-	/**
-	 * Return the mapping of names and models of detectors from which data will
-	 * be recorded during the scan.
-	 * 
-	 * @return Map<String, IDetectorModel> Key String names of detectors and 
-	 *         detector models.
-	 */
-	public Map<String, Object> getDetectorModels() {
-		return detectorModels;
-	}
-
-	/**
-	 * Replace the mapping of names and models of detectors from which data 
-	 * will be recorded during the scan.
-	 * 
-	 * @param Map<String, IDetectorModel> Key String names of detectors and 
-	 *         detector models.
-	 */
-	public void setDetectorModels(Map<String, Object> detModels) {
-		this.detectorModels = detModels;
-	}
-	
-	/**
-	 * Add a detector to the collection of detectors from which data will be 
-	 * recorded during the scan.
-	 * 
-	 * @param detName String name of detector.
-	 * @param detModel IDetectorModel configuration of detector.
-	 */
-	public void addDetector(String detName, IDetectorModel detModel) {
-		detectorModels.put(detName, detModel);
-	}
-	
-	/**
-	 * Remove a detector from the collection of detectors from which data will 
-	 * be recorded during the scan.
-	 * 
-	 * @param String name of detector to be removed.
-	 */
-	public void removeDetector(String detName) {
-		detectorModels.remove(detName);
-	}
-	
 	@Override
 	public String getQueueMessage() {
 		return queueMessage;
@@ -243,11 +145,9 @@ public class ScanAtom extends QueueAtom implements IHasChildQueue {
 	public int hashCode() {
 		final int prime = 31;
 		int result = super.hashCode();
-		result = prime * result + ((detectorModels == null) ? 0 : detectorModels.hashCode());
-		result = prime * result + ((monitors == null) ? 0 : monitors.hashCode());
-		result = prime * result + ((pathModels == null) ? 0 : pathModels.hashCode());
 		result = prime * result + ((queueMessage == null) ? 0 : queueMessage.hashCode());
 		result = prime * result + ((scanBrokerURI == null) ? 0 : scanBrokerURI.hashCode());
+		result = prime * result + ((scanReq == null) ? 0 : scanReq.hashCode());
 		result = prime * result + ((scanStatusTopicName == null) ? 0 : scanStatusTopicName.hashCode());
 		result = prime * result + ((scanSubmitQueueName == null) ? 0 : scanSubmitQueueName.hashCode());
 		return result;
@@ -262,21 +162,6 @@ public class ScanAtom extends QueueAtom implements IHasChildQueue {
 		if (getClass() != obj.getClass())
 			return false;
 		ScanAtom other = (ScanAtom) obj;
-		if (detectorModels == null) {
-			if (other.detectorModels != null)
-				return false;
-		} else if (!detectorModels.equals(other.detectorModels))
-			return false;
-		if (monitors == null) {
-			if (other.monitors != null)
-				return false;
-		} else if (!monitors.equals(other.monitors))
-			return false;
-		if (pathModels == null) {
-			if (other.pathModels != null)
-				return false;
-		} else if (!pathModels.equals(other.pathModels))
-			return false;
 		if (queueMessage == null) {
 			if (other.queueMessage != null)
 				return false;
@@ -286,6 +171,11 @@ public class ScanAtom extends QueueAtom implements IHasChildQueue {
 			if (other.scanBrokerURI != null)
 				return false;
 		} else if (!scanBrokerURI.equals(other.scanBrokerURI))
+			return false;
+		if (scanReq == null) {
+			if (other.scanReq != null)
+				return false;
+		} else if (!scanReq.equals(other.scanReq))
 			return false;
 		if (scanStatusTopicName == null) {
 			if (other.scanStatusTopicName != null)

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/queues/beans/SubTaskAtom.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/queues/beans/SubTaskAtom.java
@@ -51,6 +51,7 @@ public class SubTaskAtom extends QueueAtom implements IHasAtomQueue<QueueAtom> {
 
 	/**
 	 * Basic constructor to set String name of atom
+	 * 
 	 * @param name String user-supplied name
 	 */
 	public SubTaskAtom(String name) {
@@ -171,16 +172,15 @@ public class SubTaskAtom extends QueueAtom implements IHasAtomQueue<QueueAtom> {
 
 	@Override
 	public String toString() {
+		String clazzName = this.getClass().getSimpleName();
 		String atomQueueStr = "{";
 		for (QueueAtom qa : atomQueue) {
-			atomQueueStr = atomQueueStr+qa.getName()+" : "+qa.getStatus();
-			if (qa.getStatus().isRunning())
-				atomQueueStr = atomQueueStr+"("+qa.getPercentComplete()+")";
+			atomQueueStr = atomQueueStr + qa.getShortName() + "('" + qa.getName() + "')";
 			atomQueueStr = atomQueueStr+", ";
 		}
 		atomQueueStr = atomQueueStr.replaceAll(", $", "}"); //Replace trailing ", "
 		
-		return "SubTaskAtom [name=" + name + ", atomQueue=" + atomQueueStr + ", status=" + status
+		return clazzName + " [name=" + name + ", atomQueue=" + atomQueueStr + ", status=" + status
 				+ ", message=" + message + ", queueMessage=" + queueMessage + ", percentComplete=" 
 				+ percentComplete + ", previousStatus=" + previousStatus + ", runTime=" + runTime 
 				+ ", userName=" + userName+ ", hostName=" + hostName + ", beamline="+ beamline 

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/queues/beans/TaskBean.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/queues/beans/TaskBean.java
@@ -174,9 +174,7 @@ public class TaskBean extends QueueBean implements IHasAtomQueue<SubTaskAtom> {
 	public String toString() {
 		String atomQueueStr = "{";
 		for (QueueAtom qa : atomQueue) {
-			atomQueueStr = atomQueueStr+qa.getName()+" : "+qa.getStatus();
-			if (qa.getStatus().isRunning())
-				atomQueueStr = atomQueueStr+"("+qa.getPercentComplete()+")";
+			atomQueueStr = atomQueueStr + qa.getShortName() + "('" + qa.getName() + "')";
 			atomQueueStr = atomQueueStr+", ";
 		}
 		atomQueueStr = atomQueueStr.replaceAll(", $", "}"); //Replace trailing ", "

--- a/org.eclipse.scanning.connector.activemq.test/src/org/eclipse/scanning/connector/activemq/test/ActivemqConnectorServiceJsonMarshallingTest.java
+++ b/org.eclipse.scanning.connector.activemq.test/src/org/eclipse/scanning/connector/activemq/test/ActivemqConnectorServiceJsonMarshallingTest.java
@@ -30,6 +30,7 @@ import org.eclipse.scanning.points.classregistry.ScanningAPIClassRegistry;
 import org.eclipse.scanning.points.serialization.PointsModelMarshaller;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -172,6 +173,7 @@ public class ActivemqConnectorServiceJsonMarshallingTest {
 	}
 
 	@Test
+	@Ignore("Fails on travis - cannot reproduce; don't see why")
 	public void testObjectArrayDeserialization() throws Exception {
 		Object[] actual = marshaller.unmarshal("[ \"a\", \"b\", 5 ]", Object[].class);
 		assertArrayEquals(actual, new Object[] { "a", "b", 5 });

--- a/org.eclipse.scanning.connector.activemq.test/src/org/eclipse/scanning/connector/activemq/test/ActivemqConnectorServiceJsonMarshallingTest.java
+++ b/org.eclipse.scanning.connector.activemq.test/src/org/eclipse/scanning/connector/activemq/test/ActivemqConnectorServiceJsonMarshallingTest.java
@@ -30,7 +30,6 @@ import org.eclipse.scanning.points.classregistry.ScanningAPIClassRegistry;
 import org.eclipse.scanning.points.serialization.PointsModelMarshaller;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -173,7 +172,6 @@ public class ActivemqConnectorServiceJsonMarshallingTest {
 	}
 
 	@Test
-	@Ignore("Fails on travis - cannot reproduce; don't see why")
 	public void testObjectArrayDeserialization() throws Exception {
 		Object[] actual = marshaller.unmarshal("[ \"a\", \"b\", 5 ]", Object[].class);
 		assertArrayEquals(actual, new Object[] { "a", "b", 5 });

--- a/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/QueueProcessFactory.java
+++ b/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/QueueProcessFactory.java
@@ -19,6 +19,7 @@ import org.eclipse.scanning.api.event.core.IPublisher;
 import org.eclipse.scanning.api.event.queues.IQueueProcess;
 import org.eclipse.scanning.api.event.queues.beans.Queueable;
 import org.eclipse.scanning.api.event.status.Status;
+import org.eclipse.scanning.event.queues.processes.MonitorAtomProcess;
 import org.eclipse.scanning.event.queues.processes.PositionerAtomProcess;
 import org.eclipse.scanning.event.queues.processes.ScanAtomProcess;
 import org.eclipse.scanning.event.queues.processes.SubTaskAtomProcess;
@@ -74,8 +75,8 @@ public class QueueProcessFactory {
 		//Register default processors
 		try {
 			QueueProcessFactory.registerProcesses(PositionerAtomProcess.class,
-					ScanAtomProcess.class, SubTaskAtomProcess.class, 
-					TaskBeanProcess.class);// MonitorAtomProcessor.class,
+					ScanAtomProcess.class, MonitorAtomProcess.class, 
+					SubTaskAtomProcess.class, TaskBeanProcess.class);
 		} catch (EventException evEx) {
 			logger.error("Initial configuration of QueueProcessorFactory failed. Could not register processor(s): "+evEx.getMessage());
 		}

--- a/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/QueueService.java
+++ b/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/QueueService.java
@@ -186,13 +186,17 @@ public class QueueService extends QueueControllerService implements IQueueServic
 		logger.debug("Force-stopping active-queue(s)...");
 		if (active) stop(true);
 		
-		//Shutdown the responder
-		logger.debug("Disconnecting queueResponder...");
-		queueResponder.disconnect();
+		if (queueResponder != null) {
+			//Shutdown the responder
+			logger.debug("Disconnecting queueResponder...");
+			queueResponder.disconnect();
+		}
 
 		//Dispose the job queue
-		disconnectAndClear(jobQueue);
-		jobQueue = null;
+		if (jobQueue != null) {
+			disconnectAndClear(jobQueue);
+			jobQueue = null;
+		}
 		jobQueueID = null;
 		
 		//Mark the service not initialised

--- a/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/IPostMatchAnalyser.java
+++ b/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/IPostMatchAnalyser.java
@@ -20,19 +20,25 @@ public interface IPostMatchAnalyser {
 	 * When the processed bean has a percentComplete of 99.5% or more.
 	 * @throws EventException if event infrastructure clean-up fails.
 	 */
-	void postMatchCompleted() throws EventException;
+	default void postMatchCompleted() throws EventException {
+		//Implement as required
+	};
 	
 	/**
 	 * When the queueProcess has been marked terminated=true
 	 * @throws EventException if event infrastructure clean-up fails.
 	 */
-	void postMatchTerminated() throws EventException;
+	default void postMatchTerminated() throws EventException {
+		//Implement as required
+	};
 	
 	/**
 	 * When the state of the processed bean is unclear (e.g. not marked 
 	 * terminated or >99.5% complete).
 	 * @throws EventException if event infrastructure clean-up fails.
 	 */
-	void postMatchFailed() throws EventException;
+	default void postMatchFailed() throws EventException {
+		//Implement as required
+	};
 
 }

--- a/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/IPostMatchAnalyser.java
+++ b/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/IPostMatchAnalyser.java
@@ -1,0 +1,38 @@
+package org.eclipse.scanning.event.queues.processes;
+
+import org.eclipse.scanning.api.event.EventException;
+/**
+ * Interface to provide methods to handle different behaviours of concrete 
+ * instances of {@link QueueProcess} at end of processing. Methods are calls 
+ * by the the postMatchAnalysis method of {@link QueueProcess} depending on 
+ * processed bean state/percent complete.
+ *  
+ * {@link QueueProcess} declares it implements IPostMatchAnalyser, but as an 
+ * abstract class, does not provide implementation. Thus different behaviours 
+ * can be encoded in different concrete classes. 
+ * 
+ * @author Michael Wharmby
+ *
+ */
+public interface IPostMatchAnalyser {
+	
+	/**
+	 * When the processed bean has a percentComplete of 99.5% or more.
+	 * @throws EventException if event infrastructure clean-up fails.
+	 */
+	void postMatchCompleted() throws EventException;
+	
+	/**
+	 * When the queueProcess has been marked terminated=true
+	 * @throws EventException if event infrastructure clean-up fails.
+	 */
+	void postMatchTerminated() throws EventException;
+	
+	/**
+	 * When the state of the processed bean is unclear (e.g. not marked 
+	 * terminated or >99.5% complete).
+	 * @throws EventException if event infrastructure clean-up fails.
+	 */
+	void postMatchFailed() throws EventException;
+
+}

--- a/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/MonitorAtomProcess.java
+++ b/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/MonitorAtomProcess.java
@@ -149,15 +149,12 @@ public class MonitorAtomProcess<T extends Queueable> extends QueueProcess<Monito
 		} catch (NexusException nxEx) {
 			logger.error("Failed whilst accessing NeXus file '"+filePath+"': "+nxEx.getMessage());
 			broadcast(Status.FAILED, "Problems encountered accessing NeXus file: "+nxEx.getMessage());
-			throw new EventException("Problems encountered accessing NeXus file: "+nxEx.getMessage() ,nxEx);
 		} catch (DatasetException dsEx) {
 			logger.error("Could not pass data from monitor into LazyDataset for writing");
 			broadcast(Status.FAILED, "Failed writing to LazyDataset: "+dsEx.getMessage());
-			throw new EventException("Failed writing to LazyDataset: "+dsEx.getMessage(), dsEx);
 		} catch (ScanningException scEx) {
 			logger.error("Failed to get monitor with the name '"+queueBean.getMonitor()+"': "+scEx.getMessage());
 			broadcast(Status.FAILED, "Failed to get monitor with the name '"+queueBean.getMonitor()+"'");
-			throw new EventException("Failed to get monitor with the name '"+queueBean.getMonitor()+"'", scEx);
 		} catch (InterruptedException irEx) {
 			//We were terminated. Do tidy up and stop
 			logger.debug("Processing was interrupted. Starting cleanup...");

--- a/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/MonitorAtomProcess.java
+++ b/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/MonitorAtomProcess.java
@@ -190,14 +190,14 @@ public class MonitorAtomProcess<T extends Queueable> extends QueueProcess<Monito
 	@Override
 	public void postMatchTerminated() {
 		queueBean.setMessage("Get value of '"+queueBean.getMonitor()+"' aborted (requested)");
-		logger.debug("'"+bean.getName()+"' was requested to abort");
+//TODO		logger.debug("'"+bean.getName()+"' was requested to abort");
 	}
 
-	@Override
-	public void postMatchFailed() {
-		queueBean.setStatus(Status.FAILED);//<-- Don't set message here; it's broadcast above!
-		logger.error("'"+bean.getName()+"' failed. Last message was: '"+bean.getMessage()+"'");
-	}
+//	@Override
+//	public void postMatchFailed() {
+//		queueBean.setStatus(Status.FAILED);//<-- Don't set message here; it's broadcast above!
+//		logger.error("'"+bean.getName()+"' failed. Last message was: '"+bean.getMessage()+"'");
+//	}
 	
 	@Override
 	public Class<MonitorAtom> getBeanClass() {

--- a/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/MonitorAtomProcess.java
+++ b/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/MonitorAtomProcess.java
@@ -183,20 +183,20 @@ public class MonitorAtomProcess<T extends Queueable> extends QueueProcess<Monito
 	}
 
 	@Override
-	protected void postMatchAnalysis() throws EventException, InterruptedException {
-		if (isTerminated()) {
-			queueBean.setMessage("Get value of '"+queueBean.getMonitor()+"' aborted (requested)");
-			logger.debug("'"+bean.getName()+"' was requested to abort");
-			return;
-		} else if (queueBean.getPercentComplete() >= 99.5 && !terminated) {
-			//Clean finish
-			updateBean(Status.COMPLETE, 100d, "Successfully stored current value of '"+queueBean.getMonitor()+"'");
-		} else {
-			//Scan failed
-			queueBean.setStatus(Status.FAILED);//<-- Don't set message here; it's broadcast above!
-			logger.error("'"+bean.getName()+"' failed. Last message was: '"+bean.getMessage()+"'");
-		} 
+	public void postMatchCompleted() {
+		updateBean(Status.COMPLETE, 100d, "Successfully stored current value of '"+queueBean.getMonitor()+"'");
+	}
 
+	@Override
+	public void postMatchTerminated() {
+		queueBean.setMessage("Get value of '"+queueBean.getMonitor()+"' aborted (requested)");
+		logger.debug("'"+bean.getName()+"' was requested to abort");
+	}
+
+	@Override
+	public void postMatchFailed() {
+		queueBean.setStatus(Status.FAILED);//<-- Don't set message here; it's broadcast above!
+		logger.error("'"+bean.getName()+"' failed. Last message was: '"+bean.getMessage()+"'");
 	}
 	
 	@Override

--- a/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/PositionerAtomProcess.java
+++ b/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/PositionerAtomProcess.java
@@ -142,14 +142,12 @@ public class PositionerAtomProcess<T extends Queueable> extends QueueProcess<Pos
 	public void postMatchTerminated() {
 		positionThread.interrupt();
 		queueBean.setMessage("Position change aborted before completion (requested)");
-		logger.debug("'"+bean.getName()+"' was requested to abort");
+//TODO		logger.debug("'"+bean.getName()+"' was requested to abort");
 	}
 
 	@Override
 	public void postMatchFailed() {
 		positioner.abort();
-		queueBean.setStatus(Status.FAILED);//<-- Don't set message here; it's broadcast above!
-		logger.error("'"+bean.getName()+"' failed. Last message was: '"+bean.getMessage()+"'");
 	}
 	
 	@Override

--- a/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/QueueProcess.java
+++ b/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/QueueProcess.java
@@ -131,7 +131,7 @@ public abstract class QueueProcess<Q extends Queueable, T extends Queueable>
 	 */
 	private void postMatchAnalysis() throws EventException, InterruptedException {
 		if (isTerminated()) postMatchTerminated();
-		else if (queueBean.getPercentComplete() >= 99.5) postMatchCompleted();
+		else if (queueBean.getPercentComplete() >= 99.4) postMatchCompleted();
 		else postMatchFailed();
 	};
 	

--- a/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/QueueProcess.java
+++ b/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/QueueProcess.java
@@ -130,9 +130,19 @@ public abstract class QueueProcess<Q extends Queueable, T extends Queueable>
 	 * @throws InterruptedException if the analysis lock is interrupted
 	 */
 	private void postMatchAnalysis() throws EventException, InterruptedException {
-		if (isTerminated()) postMatchTerminated();
-		else if (queueBean.getPercentComplete() >= 99.4) postMatchCompleted();
-		else postMatchFailed();
+		if (isTerminated()) {
+			logger.debug("'"+bean.getName()+"' was requested to abort");
+			postMatchTerminated();
+		}
+		else if (queueBean.getPercentComplete() >= 99.4) {
+			postMatchCompleted();
+			updateBean(Status.COMPLETE, 100d, null);
+		}
+		else {
+			logger.error("'"+bean.getName()+"' failed. Last message was: '"+bean.getMessage()+"'");
+			postMatchFailed();
+			queueBean.setStatus(Status.FAILED);
+		}
 	};
 	
 	/**

--- a/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/ScanAtomProcess.java
+++ b/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/ScanAtomProcess.java
@@ -26,9 +26,7 @@ import org.eclipse.scanning.api.event.queues.beans.QueueAtom;
 import org.eclipse.scanning.api.event.queues.beans.Queueable;
 import org.eclipse.scanning.api.event.queues.beans.ScanAtom;
 import org.eclipse.scanning.api.event.scan.ScanBean;
-import org.eclipse.scanning.api.event.scan.ScanRequest;
 import org.eclipse.scanning.api.event.status.Status;
-import org.eclipse.scanning.api.points.models.CompoundModel;
 import org.eclipse.scanning.api.ui.CommandConstants;
 import org.eclipse.scanning.event.queues.QueueProcessFactory;
 import org.eclipse.scanning.event.queues.ServicesHolder;
@@ -81,8 +79,6 @@ public class ScanAtomProcess<T extends Queueable> extends QueueProcess<ScanAtom,
 
 	@Override
 	protected void run() throws EventException, InterruptedException {
-		executed = true;
-
 		//Get config for scanning infrastructure
 		URI scanBrokerURI;
 		String scanStatusTopicName, scanSubmitQueueName;
@@ -112,12 +108,6 @@ public class ScanAtomProcess<T extends Queueable> extends QueueProcess<ScanAtom,
 		}
 		logger.debug("Found scanSubmitQueue="+scanSubmitQueueName);
 		
-		broadcast(Status.RUNNING, 1d, "Creating scan request from configured values.");
-		ScanRequest<?> scanReq = new ScanRequest<>();
-		scanReq.setCompoundModel(new CompoundModel<>(queueBean.getPathModels()));
-		scanReq.setDetectors(queueBean.getDetectorModels());
-		scanReq.setMonitorNames(queueBean.getMonitors());
-		
 		broadcast(Status.RUNNING, 2d, "Setting up ScanBean");
 		scanBean = new ScanBean();
 		if (scanBean.getUniqueId() == null) scanBean.setUniqueId(UUID.randomUUID().toString());
@@ -125,7 +115,7 @@ public class ScanAtomProcess<T extends Queueable> extends QueueProcess<ScanAtom,
 		scanBean.setName(queueBean.getName());
 		scanBean.setHostName(queueBean.getHostName());
 		scanBean.setUserName(queueBean.getUserName());
-		scanBean.setScanRequest(scanReq);
+		scanBean.setScanRequest(queueBean.getScanReq());
 		
 		broadcast(Status.RUNNING, 3d, "Creating scanning infrastructure.");
 		logger.debug("Creating scan command publisher, submitter and subscriber...");
@@ -146,7 +136,7 @@ public class ScanAtomProcess<T extends Queueable> extends QueueProcess<ScanAtom,
 		try {
 			scanSubmitter.submit(scanBean);
 			scanSubmitter.disconnect();
-			logger.debug("Submitted ScanBean ('"+scanBean.getName()+"') generated from '"+queueBean.getName()+"' and disconnected submitter");
+			logger.info("Submitted ScanBean ('"+scanBean.getName()+"') generated from '"+queueBean.getName()+"' and disconnected submitter");
 		} catch (EventException evEx) {
 			commandScanBean(Status.REQUEST_TERMINATE); //Just in case the submission worked, but the disconnect didn't, stop the runnning process
 			broadcast(Status.FAILED, "Failed to submit scan bean to scanning system: \""+evEx.getMessage()+"\".");
@@ -156,70 +146,33 @@ public class ScanAtomProcess<T extends Queueable> extends QueueProcess<ScanAtom,
 		
 		//Allow scan to run
 		broadcast(Status.RUNNING, 5d, "Waiting for scan to complete...");
-//		processLatch.await();
 	}
 
 	@Override
 	protected void postMatchAnalysis() throws EventException, InterruptedException {
-		try {
-			postMatchAnalysisLock.lockInterruptibly();
-			if (isTerminated()) {
-				//Do different things if terminate was requested from the child
-				if (queueListener.isChildCommand()) {
-					queueBean.setMessage("Scan aborted by scanning service.");
-					logger.debug("'"+queueBean.getName()+"' was aborted by the scanning service.");
-				} else {
-					queueBean.setMessage("Scan requested to abort before completion");
-					logger.debug("'"+bean.getName()+"' was requested to abort");
-					commandScanBean(Status.REQUEST_TERMINATE);
-				}
-			} else if (queueBean.getPercentComplete() >= 99.5) {
-				//Completed successfully
-				updateBean(Status.COMPLETE, 100d, "Scan completed.");
+		if (isTerminated()) {
+			//Do different things if terminate was requested from the child
+			if (queueListener.isChildCommand()) {
+				//Nothing really to be done except set message
+				queueBean.setMessage("Scan aborted by scanning service");
+				logger.debug("'"+queueBean.getName()+"' was aborted by the scanning service");
 			} else {
-				//Scan failed - don't set anything here as messages should have 
-				//been updated elsewhere (i.e. QueueListener)
-				queueBean.setStatus(Status.FAILED);
+				queueBean.setMessage("Scan requested to abort before completion");
+				logger.debug("'"+bean.getName()+"' was requested to abort");
+				commandScanBean(Status.REQUEST_TERMINATE);
 			}
-		} finally {
-			//This should be run after we've reported the queue final state
-			tidyScanActors();
-			
-			//And we're done, so let other processes continue
-			executionEnded();
-			
-			postMatchAnalysisLock.unlock();
-			
-			/*
-			 * N.B. Broadcasting needs to be done last; otherwise the next 
-			 * queue may start when we're not ready. Broadcasting should not 
-			 * happen if we've been terminated.
-			 */
-			if (!isTerminated()) {
-				broadcast();
-			}
+		} else if (queueBean.getPercentComplete() >= 99.5) {
+			//Completed successfully
+			updateBean(Status.COMPLETE, 100d, "Scan completed successfully");
+		} else {
+			//Scan failed - don't set anything here as messages should have 
+			//been updated elsewhere (i.e. QueueListener)
+			queueBean.setStatus(Status.FAILED);
+			logger.error("'"+bean.getName()+"' failed. Last message was: "+bean.getMessage());
 		}
-	}
-	
-	@Override
-	protected void doTerminate() throws EventException {
-		if (finished) return; //Stops spurious messages/behaviour when processing already finished
-		try {
-			//Reentrant lock ensures execution method (and hence post-match 
-			//analysis) completes before terminate does
-			postMatchAnalysisLock.lockInterruptibly();
-			
-			terminated = true;
-			logger.debug("Termination of '"+queueBean.getName()+"' requested; release processLatch (start post-match analysis)");
-			processLatch.countDown();
-			
-			//Wait for post-match analysis to finish
-			continueIfExecutionEnded();
-		} catch (InterruptedException iEx) {
-			throw new EventException(iEx);
-		} finally {
-			postMatchAnalysisLock.unlock();
-		}
+
+		//This should be run after we've reported the queue final state
+		tidyScanActors();
 	}
 	
 	@Override
@@ -228,8 +181,8 @@ public class ScanAtomProcess<T extends Queueable> extends QueueProcess<ScanAtom,
 //		if (!queueListener.isChildCommand()) {
 //			commandScanBean(Status.REQUEST_PAUSE);
 //		}
-		//TODO!
-		logger.warn("Resume not implemented on ScanAtomProcessor");
+		//TODO
+		logger.error("Pause/resume not implemented on ScanAtom");
 	}
 
 	@Override
@@ -239,7 +192,7 @@ public class ScanAtomProcess<T extends Queueable> extends QueueProcess<ScanAtom,
 //			commandScanBean(Status.REQUEST_RESUME);
 //		}
 		//TODO!
-		logger.warn("Pause not implemented on ScanAtomProcessor");
+		logger.error("Pause/resume not implemented on ScanAtom");
 	}
 
 	
@@ -265,7 +218,7 @@ public class ScanAtomProcess<T extends Queueable> extends QueueProcess<ScanAtom,
 		}
 		scanBean.setStatus(command);
 		scanCommandPublisher.broadcast(scanBean);
-		logger.debug("Sent command to scan service (command="+command+")");
+		logger.info("Sent command to scan service (ScanBean='"+scanBean.getName()+"' command="+command+")");
 	}
 	
 	/**

--- a/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/SubTaskAtomProcess.java
+++ b/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/SubTaskAtomProcess.java
@@ -54,82 +54,40 @@ public class SubTaskAtomProcess<T extends Queueable> extends QueueProcess<SubTas
 
 	@Override
 	protected void run() throws EventException, InterruptedException {
-		executed = true;
 		//Do most of the work of processing in the atomQueueProcessor...
 		atomQueueProcessor.run();
 	}
 	
 	@Override 
 	protected void postMatchAnalysis() throws EventException, InterruptedException {
-		//...do the post-match analysis in here!
-		try {
-			postMatchAnalysisLock.lockInterruptibly();
-			if (isTerminated()) {
-				atomQueueProcessor.terminate();
-				logger.debug("'"+bean.getName()+"' was requested to abort");
-				queueBean.setMessage("Active-queue was requested to abort before completion");
-			}else if (queueBean.getPercentComplete() >= 99.49) {//99.49 to catch rounding errors
-				//Completed successfully
-				updateBean(Status.COMPLETE, 100d, "Scan completed.");
-			} else {
-				//Failed: latch released before completion
-				updateBean(Status.FAILED, null, "Active-queue failed (caused by atom in queue)");
-				logger.info("'"+bean.getName()+"' failed");
-			}
-		} finally {
-			//This should be run after we've reported the queue final state
-			//This must be after unlock call, otherwise terminate gets stuck.
-			atomQueueProcessor.tidyQueue();
-			
-			//And we're done, so let other processes continue
-			executionEnded();
-			
-			postMatchAnalysisLock.unlock();
-
-			/*
-			 * N.B. Broadcasting needs to be done last; otherwise the next 
-			 * queue may start when we're not ready. Broadcasting should not 
-			 * happen if we've been terminated.
-			 */
-			if (!isTerminated()) {
-				broadcast();
-			}
+		if (isTerminated()) {
+			atomQueueProcessor.terminate();
+			queueBean.setMessage("Active-queue was requested to abort before completion");
+			logger.debug("'"+bean.getName()+"' was requested to abort");
+		}else if (queueBean.getPercentComplete() >= 99.49) {//99.49 to catch rounding errors
+			//Completed successfully
+			updateBean(Status.COMPLETE, 100d, "Scan completed.");
+		} else {
+			//Failed: latch released before completion
+			updateBean(Status.FAILED, null, "Active-queue failed (caused by atom in queue)");
+			logger.error("'"+bean.getName()+"' failed. Last message was: '"+bean.getMessage()+"'");
 		}
-	}
-	
-	@Override
-	protected void doTerminate() throws EventException {
-		if (finished) return; //Stops spurious messages/behaviour when processing already finished
-		try {
-			//Reentrant lock ensures execution method (and hence post-match 
-			//analysis) completes before terminate does
-			postMatchAnalysisLock.lockInterruptibly();
-
-			terminated = true;
-			logger.debug("Termination of '"+queueBean.getName()+"' requested; release processLatch (start post-match analysis)");
-			processLatch.countDown();
-			
-			//Wait for post-match analysis to finish
-			continueIfExecutionEnded();
-		} catch (InterruptedException iEx) {
-			throw new EventException(iEx);
-		} finally {
-			postMatchAnalysisLock.unlock();
-		}
+		//This should be run after we've reported the queue final state
+		atomQueueProcessor.tidyQueue();
 	}
 	
 	@Override
 	protected void doPause() throws Exception {
 		if (finished) return; //Stops spurious messages/behaviour when processing already finished
 		//TODO!
-		logger.warn("Pause not implemented on SubTaskAtomProcessor");
+		logger.warn("Pause/resume not implemented on SubTaskAtom");
 	}
 	
 	@Override
 	protected void doResume() throws Exception {
 		if (finished) return; //Stops spurious messages/behaviour when processing already finished
 		//TODO!
-		logger.warn("Resume not implemented on SubTaskAtomProcessor");
+		logger.warn("Pause/resume not implemented on SubTaskAtom");
 	}
 
 	@Override

--- a/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/SubTaskAtomProcess.java
+++ b/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/SubTaskAtomProcess.java
@@ -68,14 +68,13 @@ public class SubTaskAtomProcess<T extends Queueable> extends QueueProcess<SubTas
 	public void postMatchTerminated() throws EventException {
 		atomQueueProcessor.terminate();
 		queueBean.setMessage("Active-queue was requested to abort before completion");
-		logger.debug("'"+bean.getName()+"' was requested to abort");
+//TODO		logger.debug("'"+bean.getName()+"' was requested to abort");
 		atomQueueProcessor.tidyQueue();
 	}
 
 	@Override
 	public void postMatchFailed() throws EventException {
-		updateBean(Status.FAILED, null, "Active-queue failed (caused by atom in queue)");
-		logger.error("'"+bean.getName()+"' failed. Last message was: '"+bean.getMessage()+"'");
+		queueBean.setMessage("Active-queue failed (caused by atom in queue)");
 		atomQueueProcessor.tidyQueue();
 	}
 	

--- a/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/TaskBeanProcess.java
+++ b/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/TaskBeanProcess.java
@@ -57,85 +57,43 @@ public class TaskBeanProcess<T extends Queueable> extends QueueProcess<TaskBean,
 
 	@Override
 	protected void run() throws EventException, InterruptedException {
-		executed = true;
 		//Do most of the work of processing in the atomQueueProcessor...
 		atomQueueProcessor.run();
 	}
 
 	@Override
 	protected void postMatchAnalysis() throws EventException, InterruptedException {
-		//...do the post-match analysis in this class!
-		try {
-			postMatchAnalysisLock.lockInterruptibly();
-			if (isTerminated()) {
-				atomQueueProcessor.terminate();
-				logger.debug("'"+bean.getName()+"' was requested to abort");
-				queueBean.setMessage("Job-queue was requested to abort before completion");
-			}else if (queueBean.getPercentComplete() >= 99.49) {//99.49 to catch rounding errors
-				//Completed successfully
-				updateBean(Status.COMPLETE, 100d, "Scan completed.");
-			} else {
-				//Failed: latch released before completion
-				updateBean(Status.FAILED, null, "Job-queue failed (caused by atom in queue)");
-				logger.info("'"+bean.getName()+"' failed. Job-queue paused and will not continue without user intervention");
-				//As we don't know the origin of the failure, pause *this* queue
-				IQueueControllerService controller = ServicesHolder.getQueueControllerService();
-				controller.pauseQueue(ServicesHolder.getQueueService().getJobQueueID());
-			}
-		} finally {
-			//This should be run after we've reported the queue final state
-			//This must be after unlock call, otherwise terminate gets stuck.
-			atomQueueProcessor.tidyQueue();
-			
-			//And we're done, so let other processes continue
-			executionEnded();
-			
-			postMatchAnalysisLock.unlock();
-
-			/*
-			 * N.B. Broadcasting needs to be done last; otherwise the next 
-			 * queue may start when we're not ready. Broadcasting should not 
-			 * happen if we've been terminated.
-			 */
-			if (!isTerminated()) {
-				broadcast();
-			}
+		if (isTerminated()) {
+			atomQueueProcessor.terminate();
+			logger.debug("'"+bean.getName()+"' was requested to abort");
+			queueBean.setMessage("Job-queue was requested to abort before completion");
+		}else if (queueBean.getPercentComplete() >= 99.49) {//99.49 to catch rounding errors
+			//Completed successfully
+			updateBean(Status.COMPLETE, 100d, "Scan completed.");
+		} else {
+			//Failed: latch released before completion
+			updateBean(Status.FAILED, null, "Job-queue failed (caused by atom in queue)");
+			logger.error("'"+bean.getName()+"' failed. Last message was: '"+bean.getMessage()+"'. Job-queue paused and will not continue without user intervention");
+			//As we don't know the origin of the failure, pause *this* queue
+			IQueueControllerService controller = ServicesHolder.getQueueControllerService();
+			controller.pauseQueue(ServicesHolder.getQueueService().getJobQueueID());
 		}
-	}
-	
-	@Override
-	public void doTerminate() throws EventException {
-		if (finished) return; //Stops spurious messages/behaviour when processing already finished
-		try {
-			//Reentrant lock ensures execution method (and hence post-match 
-			//analysis) completes before terminate does
-			postMatchAnalysisLock.lockInterruptibly();
-			
-			terminated = true;
-			logger.debug("Termination of '"+queueBean.getName()+"' requested; release processLatch (start post-match analysis)");
-			processLatch.countDown();
-			
-			//Wait for post-match analysis to finish
-			continueIfExecutionEnded();
-		} catch (InterruptedException iEx) {
-			throw new EventException(iEx);
-		} finally {
-			postMatchAnalysisLock.unlock();
-		}
+		//This should be run after we've reported the queue final state
+		atomQueueProcessor.tidyQueue();
 	}
 	
 	@Override
 	protected void doPause() throws Exception {
 		if (finished) return; //Stops spurious messages/behaviour when processing already finished
 		//TODO!
-		logger.warn("Pause not implemented on TaskBeanProcessor");
+		logger.warn("Pause/resume not implemented on TaskBeanProcessor");
 	}
 	
 	@Override
 	protected void doResume() throws Exception {
 		if (finished) return; //Stops spurious messages/behaviour when processing already finished
 		//TODO!
-		logger.warn("Resume not implemented on TaskBeanProcessor");
+		logger.warn("Pause/resume not implemented on TaskBeanProcessor");
 	}
 	
 	@Override

--- a/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/TaskBeanProcess.java
+++ b/org.eclipse.scanning.event.queues/src/org/eclipse/scanning/event/queues/processes/TaskBeanProcess.java
@@ -70,7 +70,6 @@ public class TaskBeanProcess<T extends Queueable> extends QueueProcess<TaskBean,
 	@Override
 	public void postMatchTerminated() throws EventException {
 		atomQueueProcessor.terminate();
-		logger.debug("'"+bean.getName()+"' was requested to abort");
 		queueBean.setMessage("Job-queue was requested to abort before completion");
 		atomQueueProcessor.tidyQueue();
 	}
@@ -78,7 +77,7 @@ public class TaskBeanProcess<T extends Queueable> extends QueueProcess<TaskBean,
 	@Override
 	public void postMatchFailed() throws EventException {
 		updateBean(Status.FAILED, null, "Job-queue failed (caused by atom in queue)");
-		logger.error("'"+bean.getName()+"' failed. Last message was: '"+bean.getMessage()+"'. Job-queue paused and will not continue without user intervention");
+		logger.warn("Job-queue paused and will not continue without user intervention");
 		//As we don't know the origin of the failure, pause *this* queue
 		IQueueControllerService controller = ServicesHolder.getQueueControllerService();
 		controller.pauseQueue(ServicesHolder.getQueueService().getJobQueueID());

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/QueueProcessCreatorTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/QueueProcessCreatorTest.java
@@ -39,6 +39,7 @@ import org.eclipse.scanning.test.event.queues.dummy.DummyHasQueueProcess;
 import org.eclipse.scanning.test.event.queues.mocks.MockPublisher;
 import org.eclipse.scanning.test.event.queues.util.TestAtomQueueBeanMaker;
 import org.eclipse.scanning.test.scan.mock.MockDetectorModel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -68,6 +69,12 @@ public class QueueProcessCreatorTest {
 		qpc = new QueueProcessCreator<>(true);
 		
 		statPub = new MockPublisher<Queueable>(null, "test.topic");
+		QueueProcessFactory.initialize();
+	}
+	
+	@After
+	public void tearDown() {
+		//Remove Dummy*Process so it doesn't cause bad behaviour in travis
 		QueueProcessFactory.initialize();
 	}
 

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/QueueProcessFactoryTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/QueueProcessFactoryTest.java
@@ -25,6 +25,7 @@ import org.eclipse.scanning.test.event.queues.dummy.DummyBeanProcess;
 import org.eclipse.scanning.test.event.queues.dummy.DummyHasQueue;
 import org.eclipse.scanning.test.event.queues.dummy.DummyHasQueueProcess;
 import org.eclipse.scanning.test.event.queues.mocks.MockPublisher;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,6 +33,12 @@ public class QueueProcessFactoryTest {
 	
 	@Before
 	public void setUp() {
+		QueueProcessFactory.initialize();
+	}
+	
+	@After
+	public void tearDown() {
+		//Remove Dummy*Process so it doesn't cause bad behaviour in travis
 		QueueProcessFactory.initialize();
 	}
 	

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/beans/MonitorAtomTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/beans/MonitorAtomTest.java
@@ -23,13 +23,12 @@ import org.junit.Before;
  */
 public class MonitorAtomTest extends AbstractBeanTest<MonitorAtom> {
 	
-	private String nameA = "testMonitorA", nameB = "testMonitorB";
+	private String shrtNmA = "testMonitorA", shrtNmB = "testMonitorB";
 	private String deviceA = "testMonDeviceA", deviceB = "testMonDeviceB";
-	private long timeA = 26430, timeB = 4329;
 	
 	@Before
 	public void buildBeans() throws Exception {
-		beanA = new MonitorAtom(nameA, deviceA, timeA);
-		beanB = new MonitorAtom(nameB, deviceB, timeB);
+		beanA = new MonitorAtom(shrtNmA, deviceA);
+		beanB = new MonitorAtom(shrtNmB, deviceB);
 	}
 }

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/beans/PositionerAtomTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/beans/PositionerAtomTest.java
@@ -14,7 +14,7 @@ package org.eclipse.scanning.test.event.queues.beans;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -32,23 +32,25 @@ import org.junit.Test;
  */
 public class PositionerAtomTest extends AbstractBeanTest<PositionerAtom> {
 	
-	private String nameA = "testMoveA", nameB = "testMoveB";
-	private String deviceA = "testDeviceA", deviceB = "testDeviceB"
-			, deviceC = "testDeviceC", deviceD = "testDeviceD";
+	private String shrtNmA = "tstMvA", shrtNmB = "tstMvB";
+	private String nameA = "Set cryostream to 273.15", nameB = "Set samX to 0.0, samY to 10 and cryojet to 273.15";
+	private String deviceA = "cryojet", deviceB = "samX", 
+			deviceC = "samY", deviceD = "blower";
 	private double targetA = 273.15, targetB = 957.845;
-	private int targetC = 1;
-	private String targetD = "barry";
+	private int targetC = 10;
+	private String targetD = "out";
 	
 	@Before
 	public void buildBeans() throws Exception {
-		Map<String, Object> beanBConf = new HashMap<>();
+		Map<String, Object> beanBConf = new LinkedHashMap<>();
 		beanBConf.put(deviceB, targetB);
 		beanBConf.put(deviceC, targetC);
 		beanBConf.put(deviceD, targetD);
-				
 		
-		beanA = new PositionerAtom(nameA, deviceA, targetA);
-		beanB = new PositionerAtom(nameB, beanBConf);
+		beanA = new PositionerAtom(shrtNmA, deviceA, targetA);
+		beanA.setName(nameA);
+		beanB = new PositionerAtom(shrtNmB, beanBConf);
+		beanB.setName(nameB);
 		
 	}
 	
@@ -64,4 +66,5 @@ public class PositionerAtomTest extends AbstractBeanTest<PositionerAtom> {
 		
 		assertEquals("Reported list and the expected list of names differ", expected, beanB.getPositionerNames());
 	}
+
 }

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/beans/ScanAtomTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/beans/ScanAtomTest.java
@@ -17,8 +17,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.scanning.api.event.queues.beans.ScanAtom;
-import org.eclipse.scanning.api.points.models.StaticModel;
+import org.eclipse.scanning.api.event.scan.ScanRequest;
+import org.eclipse.scanning.api.points.models.CompoundModel;
 import org.eclipse.scanning.api.points.models.IScanPathModel;
+import org.eclipse.scanning.api.points.models.StaticModel;
 import org.eclipse.scanning.test.scan.mock.MockDetectorModel;
 import org.junit.Before;
 
@@ -31,30 +33,36 @@ import org.junit.Before;
  */
 public class ScanAtomTest extends AbstractBeanTest<ScanAtom> {
 	
-	private String nameA = "Test scan 1", nameB = "Test scan 2";
-	private List<IScanPathModel> modelsA, modelsB;
-	private Map<String, Object> detectorsA, detectorsB;
-	private List<String> monitors;
+	private String shrtNmA = "Test scan 1", shrtNmB = "Test scan 2";
 	
 	@Before
 	public void buildBeans() {
-		detectorsA = new HashMap<>();
+		//Config for first ScanAtom
+		Map<String, Object> detectorsA = new HashMap<>();
 		detectorsA.put("Test Detector A", new MockDetectorModel(30.0));
 		detectorsA.put("Test Detector B", new MockDetectorModel(30.0));
-		detectorsB = new HashMap<>();
+		
+		List<IScanPathModel> modelsA = new ArrayList<>();
+		modelsA.add(new StaticModel());
+		
+		ScanRequest<?> scanReq = new ScanRequest<>();
+		scanReq.setDetectors(detectorsA);
+		scanReq.setCompoundModel(new CompoundModel<>(modelsA));
+		
+		
+		//Config for second ScanAtom
+		Map<String, Object> detectorsB = new HashMap<>();
 		detectorsB.put("Test Detector C", new MockDetectorModel(50.0));
 		
-		modelsA = new ArrayList<>();
-		modelsA.add(new StaticModel());
-		modelsB = new ArrayList<>();
+		List<IScanPathModel> modelsB = new ArrayList<>();
 		modelsB.add(new StaticModel());
 		modelsB.add(new StaticModel());
 		
-		monitors = new ArrayList<>();
+		List<String> monitors = new ArrayList<>();
 		monitors.add("Fake monitor");
 		
-		beanA = new ScanAtom(nameA, modelsA, detectorsA);
-		beanB = new ScanAtom(nameB, modelsB, detectorsB, monitors);
+		beanA = new ScanAtom(shrtNmA, scanReq);
+		beanB = new ScanAtom(shrtNmB, modelsB, detectorsB, monitors);
 	}
 
 }

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/dummy/DummyAtomProcess.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/dummy/DummyAtomProcess.java
@@ -28,4 +28,19 @@ public class DummyAtomProcess<T extends Queueable> extends DummyProcess<DummyAto
 		return DummyAtom.class;
 	}
 
+	@Override
+	public void postMatchCompleted() throws EventException {
+		//Not needed for DummyProcessing
+	}
+
+	@Override
+	public void postMatchTerminated() throws EventException {
+		//Not needed for DummyProcessing
+	}
+
+	@Override
+	public void postMatchFailed() throws EventException {
+		//Not needed for DummyProcessing
+	}
+
 }

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/dummy/DummyAtomProcess.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/dummy/DummyAtomProcess.java
@@ -27,20 +27,5 @@ public class DummyAtomProcess<T extends Queueable> extends DummyProcess<DummyAto
 	public Class<DummyAtom> getBeanClass() {
 		return DummyAtom.class;
 	}
-
-	@Override
-	public void postMatchCompleted() throws EventException {
-		//Not needed for DummyProcessing
-	}
-
-	@Override
-	public void postMatchTerminated() throws EventException {
-		//Not needed for DummyProcessing
-	}
-
-	@Override
-	public void postMatchFailed() throws EventException {
-		//Not needed for DummyProcessing
-	}
-
+	
 }

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/dummy/DummyBeanProcess.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/dummy/DummyBeanProcess.java
@@ -27,20 +27,5 @@ public class DummyBeanProcess<T extends Queueable> extends DummyProcess<DummyBea
 	public Class<DummyBean> getBeanClass() {
 		return DummyBean.class;
 	}
-	
-	@Override
-	public void postMatchCompleted() throws EventException {
-		//Not needed for DummyProcessing
-	}
-
-	@Override
-	public void postMatchTerminated() throws EventException {
-		//Not needed for DummyProcessing
-	}
-
-	@Override
-	public void postMatchFailed() throws EventException {
-		//Not needed for DummyProcessing
-	}
 
 }

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/dummy/DummyBeanProcess.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/dummy/DummyBeanProcess.java
@@ -27,5 +27,20 @@ public class DummyBeanProcess<T extends Queueable> extends DummyProcess<DummyBea
 	public Class<DummyBean> getBeanClass() {
 		return DummyBean.class;
 	}
+	
+	@Override
+	public void postMatchCompleted() throws EventException {
+		//Not needed for DummyProcessing
+	}
+
+	@Override
+	public void postMatchTerminated() throws EventException {
+		//Not needed for DummyProcessing
+	}
+
+	@Override
+	public void postMatchFailed() throws EventException {
+		//Not needed for DummyProcessing
+	}
 
 }

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/dummy/DummyHasQueueProcess.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/dummy/DummyHasQueueProcess.java
@@ -28,19 +28,4 @@ public class DummyHasQueueProcess<T extends Queueable> extends DummyProcess<Dumm
 		return DummyHasQueue.class;
 	}
 
-	@Override
-	public void postMatchCompleted() throws EventException {
-		//Not needed for DummyProcessing
-	}
-
-	@Override
-	public void postMatchTerminated() throws EventException {
-		//Not needed for DummyProcessing
-	}
-
-	@Override
-	public void postMatchFailed() throws EventException {
-		//Not needed for DummyProcessing
-	}
-
 }

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/dummy/DummyHasQueueProcess.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/dummy/DummyHasQueueProcess.java
@@ -28,4 +28,19 @@ public class DummyHasQueueProcess<T extends Queueable> extends DummyProcess<Dumm
 		return DummyHasQueue.class;
 	}
 
+	@Override
+	public void postMatchCompleted() throws EventException {
+		//Not needed for DummyProcessing
+	}
+
+	@Override
+	public void postMatchTerminated() throws EventException {
+		//Not needed for DummyProcessing
+	}
+
+	@Override
+	public void postMatchFailed() throws EventException {
+		//Not needed for DummyProcessing
+	}
+
 }

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/dummy/DummyProcess.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/dummy/DummyProcess.java
@@ -55,12 +55,6 @@ public abstract class DummyProcess<Q extends Queueable, T extends Queueable> ext
 	protected void run() throws EventException, InterruptedException {
 		//Do nothing - this is not needed for Dummy processing
 	}
-
-	@Override
-	protected void postMatchAnalysis() throws EventException, InterruptedException {
-		//Do nothing - this is not needed for Dummy processing
-		
-	}
 	
 	@Override
 	public void doTerminate() throws EventException {

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/integration/QueueServiceIntegrationPluginTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/integration/QueueServiceIntegrationPluginTest.java
@@ -75,6 +75,7 @@ public class QueueServiceIntegrationPluginTest extends BrokerTest {
 	
 	@After
 	public void tearDown() throws EventException {
+		QueueProcessFactory.initialize(); //Remove the registered processes
 		queueControl.stopQueueService(false);
 		queueService.disposeService();
 		

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/mocks/MockPublisher.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/mocks/MockPublisher.java
@@ -24,6 +24,7 @@ import org.eclipse.scanning.api.event.alive.PauseBean;
 import org.eclipse.scanning.api.event.core.IConsumer;
 import org.eclipse.scanning.api.event.core.IPublisher;
 import org.eclipse.scanning.api.event.queues.beans.IHasChildQueue;
+import org.eclipse.scanning.api.event.queues.beans.MonitorAtom;
 import org.eclipse.scanning.api.event.queues.beans.Queueable;
 import org.eclipse.scanning.api.event.queues.beans.ScanAtom;
 import org.eclipse.scanning.api.event.status.StatusBean;
@@ -99,7 +100,10 @@ public class MockPublisher<T> implements IPublisher<T> {
 					((DummyHasQueue)broadBean).setQueueMessage(((IHasChildQueue)bean).getQueueMessage());
 				}
 				
-			} else {
+			} if (bean instanceof MonitorAtom) {
+				broadBean = new MonitorAtom();
+				((MonitorAtom)broadBean).setFilePath(((MonitorAtom)bean).getFilePath());
+			}else {
 				broadBean = new StatusBean(); 
 			}
 			StatusBean loBean = (StatusBean)bean;

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/mocks/MockPublisher.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/mocks/MockPublisher.java
@@ -100,10 +100,10 @@ public class MockPublisher<T> implements IPublisher<T> {
 					((DummyHasQueue)broadBean).setQueueMessage(((IHasChildQueue)bean).getQueueMessage());
 				}
 				
-			} if (bean instanceof MonitorAtom) {
+			} else if (bean instanceof MonitorAtom) {
 				broadBean = new MonitorAtom();
 				((MonitorAtom)broadBean).setFilePath(((MonitorAtom)bean).getFilePath());
-			}else {
+			} else {
 				broadBean = new StatusBean(); 
 			}
 			StatusBean loBean = (StatusBean)bean;

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/processes/MonitorAtomProcessTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/processes/MonitorAtomProcessTest.java
@@ -22,7 +22,6 @@ import org.eclipse.dawnsci.analysis.api.tree.DataNode;
 import org.eclipse.dawnsci.hdf5.nexus.NexusFileFactoryHDF5;
 import org.eclipse.dawnsci.nexus.INexusFileFactory;
 import org.eclipse.dawnsci.nexus.NexusFile;
-import org.eclipse.scanning.api.device.IRunnableDeviceService;
 import org.eclipse.scanning.api.event.EventException;
 import org.eclipse.scanning.api.event.queues.beans.MonitorAtom;
 import org.eclipse.scanning.api.event.queues.beans.Queueable;
@@ -33,11 +32,8 @@ import org.eclipse.scanning.event.queues.processes.MonitorAtomProcess;
 import org.eclipse.scanning.event.queues.processes.QueueProcess;
 import org.eclipse.scanning.example.file.MockFilePathService;
 import org.eclipse.scanning.example.scannable.MockScannableConnector;
-import org.eclipse.scanning.test.event.queues.mocks.MockPositioner;
-import org.eclipse.scanning.test.event.queues.mocks.MockScanService;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class MonitorAtomProcessTest {
@@ -47,27 +43,23 @@ public class MonitorAtomProcessTest {
 	
 	//Infrastructure
 	private ProcessTestInfrastructure pti;
-	private IRunnableDeviceService mss;
 	
 	@Before
 	public void setUp() throws EventException {
 		
 		pti = new ProcessTestInfrastructure(750);
 		
-		mss = new MockScanService();
-		ServicesHolder.setDeviceService(mss);
 		ServicesHolder.setNexusFileFactory(new NexusFileFactoryHDF5());
 		ServicesHolder.setScannableDeviceService(new MockScannableConnector(null));
 		ServicesHolder.setFilePathService(new MockFilePathService());
 		
-		monAt = new MonitorAtom("Monitor temperature", "T", 12000);
+		monAt = new MonitorAtom("getTC1", "thermocouple1");
+		monAt.setName("Monitor thermocouple1");
 		monAtProc = new MonitorAtomProcess<>(monAt, pti.getPublisher(), false);
 	}
 	
 	@After
 	public void tearDown() {
-		ServicesHolder.unsetDeviceService(mss);
-		mss = null;
 		pti = null;
 	}
 	
@@ -83,7 +75,9 @@ public class MonitorAtomProcessTest {
 		pti.waitForExecutionEnd(10000l);
 		pti.checkLastBroadcastBeanStatuses(Status.COMPLETE, false);
 		
-		assertEquals("Incorrect message after execute", "Device move(s) completed.", pti.getLastBroadcastBean().getMessage());
+		assertEquals("Incorrect message after execute", "Successfully stored current value of 'thermocouple1'", pti.getLastBroadcastBean().getMessage());
+		
+		assertEquals(monAt.getRunDirectory(), new File(monAt.getFilePath()).getParent());
 		
 		final File file = new File(monAt.getFilePath());
 		assertTrue(file.exists());
@@ -110,18 +104,18 @@ public class MonitorAtomProcessTest {
 	 * N.B. MoveAtomProcessorTest uses MockPostioner, which pauses for 100ms 
 	 * does something then pauses for 150ms.
 	 */
-	@Ignore("I do not understand why this fails.")
 	@Test
 	public void testTermination() throws Exception {
-		pti.executeProcess(monAtProc, monAt);
-		pti.waitToTerminate(100l);
+		pti.executeProcess(monAtProc, monAt, false, false);
+		pti.waitToTerminate(0l);
 		pti.waitForBeanFinalStatus(5000l);
 		pti.checkLastBroadcastBeanStatuses(Status.TERMINATED, false);
 		
 		Thread.sleep(100);
-		assertEquals("Incorrect message after terminate", "Move aborted before completion (requested).", pti.getLastBroadcastBean().getMessage());
-		assertTrue("IPositioner not aborted", ((MockPositioner)mss.createPositioner()).isAborted());
-		assertFalse("Move should have been terminated", ((MockPositioner)mss.createPositioner()).isMoveComplete());
+		assertEquals("Incorrect message after terminate", "Get value of 'thermocouple1' aborted (requested)", pti.getLastBroadcastBean().getMessage());
+		//Get the filepath set for the monitor output and check it does not exist
+		MonitorAtom termAt = (MonitorAtom)pti.getLastBroadcastBean();
+		assertFalse("Nexus file not deleted during cleanup", new File(termAt.getFilePath()).exists());
 	}
 	
 //	@Test
@@ -138,16 +132,17 @@ public class MonitorAtomProcessTest {
 	 */
 	@Test
 	public void testFailure() throws Exception {
-		MonitorAtom failAtom = new MonitorAtom("Error Causer", null, 1);
-		MonitorAtomProcess mvAtProc = new MonitorAtomProcess<>(failAtom, pti.getPublisher(), false);
+		MonitorAtom failAtom = new MonitorAtom("error", null);
+		failAtom.setName("Error Causer");
+		monAtProc = new MonitorAtomProcess<>(failAtom, pti.getPublisher(), false);
 		
-		pti.executeProcess(mvAtProc, failAtom);
+		pti.executeProcess(monAtProc, failAtom);
 		//Fail happens automatically since using MockDev.Serv.
 		pti.waitForBeanFinalStatus(5000l);
 		pti.checkLastBroadcastBeanStatuses(Status.FAILED, false);
 		
 		StatusBean lastBean = pti.getLastBroadcastBean();
-		assertEquals("Write of file with value from 'null' failed with: \"Invalid scannable null\".", lastBean.getMessage());
+		assertEquals("Failed to get monitor with the name 'null'", lastBean.getMessage());
 	}
 
 }

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/processes/PositionerAtomProcessTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/processes/PositionerAtomProcessTest.java
@@ -46,7 +46,8 @@ public class PositionerAtomProcessTest {
 		mss = new MockScanService();
 		ServicesHolder.setDeviceService(mss);
 		
-		posAt = new PositionerAtom("Move robot arm", "robot_arm", "1250");
+		posAt = new PositionerAtom("mvRbtRm", "robot_arm", "1250");
+		posAt.setName("Move robot arm");
 		posAtProc = new PositionerAtomProcess<>(posAt, pti.getPublisher(), false);
 	}
 	
@@ -70,7 +71,7 @@ public class PositionerAtomProcessTest {
 		pti.waitForExecutionEnd(10000l);
 		pti.checkLastBroadcastBeanStatuses(Status.COMPLETE, false);
 		
-		assertEquals("Incorrect message after execute", "Position change completed.", pti.getLastBroadcastBean().getMessage());
+		assertEquals("Incorrect message after execute", "Set position completed successfully", pti.getLastBroadcastBean().getMessage());
 	}
 	
 	/**
@@ -92,7 +93,7 @@ public class PositionerAtomProcessTest {
 		pti.checkLastBroadcastBeanStatuses(Status.TERMINATED, false);
 		
 		pti.waitForExecutionEnd(500);
-		assertEquals("Incorrect message after terminate", "Position change aborted before completion (requested).", pti.getLastBroadcastBean().getMessage());
+		assertEquals("Incorrect message after terminate", "Position change aborted before completion (requested)", pti.getLastBroadcastBean().getMessage());
 		assertTrue("IPositioner not aborted", ((MockPositioner)mss.createPositioner()).isAborted());
 		assertFalse("Position setting should have been terminated", ((MockPositioner)mss.createPositioner()).isMoveComplete());
 	}
@@ -112,6 +113,7 @@ public class PositionerAtomProcessTest {
 	@Test
 	public void testFailure() throws Exception {
 		PositionerAtom failAtom = new PositionerAtom("Error Causer", "BadgerApocalypseButton", "pushed");
+		failAtom.setName("Error Causer");
 		posAtProc = new PositionerAtomProcess<>(failAtom, pti.getPublisher(), false);
 		
 		pti.executeProcess(posAtProc, failAtom);
@@ -121,8 +123,7 @@ public class PositionerAtomProcessTest {
 		
 		StatusBean lastBean = pti.getLastBroadcastBean();
 		
-		String req = "Moving device(s) in '"+lastBean.getName()+
-				"' failed with: \"The badger apocalypse cometh! (EXPECTED - we pressed the button...)\".";
+		String req = "Moving device(s) in 'Error Causer' failed with: 'The badger apocalypse cometh! (EXPECTED - we pressed the button...)'";
 		assertEquals("Fail message from IPositioner incorrectly set", req, lastBean.getMessage());
 		assertTrue("IPositioner not aborted", ((MockPositioner)mss.createPositioner()).isAborted());
 	}

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/processes/SubTaskAtomProcessorIntegrationPluginTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/processes/SubTaskAtomProcessorIntegrationPluginTest.java
@@ -65,6 +65,7 @@ public class SubTaskAtomProcessorIntegrationPluginTest extends BrokerTest {
 	
 	@After
 	public void tearDown() throws EventException {
+		QueueProcessFactory.initialize(); //Remove the registered processes
 		queueControl.stopQueueService(false);
 		queueService.disposeService();
 	}

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/remote/RemoteQueueControllerServiceTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/remote/RemoteQueueControllerServiceTest.java
@@ -31,6 +31,7 @@ import org.eclipse.scanning.api.event.queues.IQueueService;
 import org.eclipse.scanning.api.event.queues.beans.Queueable;
 import org.eclipse.scanning.connector.activemq.ActivemqConnectorService;
 import org.eclipse.scanning.event.EventServiceImpl;
+import org.eclipse.scanning.event.queues.QueueProcessFactory;
 import org.eclipse.scanning.event.queues.QueueService;
 import org.eclipse.scanning.event.queues.ServicesHolder;
 import org.eclipse.scanning.event.remote.RemoteServiceFactory;
@@ -93,6 +94,9 @@ public class RemoteQueueControllerServiceTest extends BrokerTest {
 		
 		//Last thing, reset the support utils.
 		RealQueueTestUtils.initialise(uri);
+		
+		//In travis submitRemove test fails because bean is consumed; reset QueueProcessFactory to prevent this
+		QueueProcessFactory.initialize();
 		
 	}
 	
@@ -194,7 +198,7 @@ public class RemoteQueueControllerServiceTest extends BrokerTest {
 		//For all submit/remove testing we don't want to process anything
 		qservice.pauseQueue(jqID);
 		qservice.pauseQueue(aqID);
-		Thread.sleep(100); //PauseBean takes time to have an effect
+		Thread.sleep(500); //PauseBean takes time to have an effect (increased time from 100)
 		
 		//Beans for submission
 		DummyBean albert = new DummyBean("Albert", 10),bernard = new DummyBean("Bernard", 20), fred = new DummyBean("Fred", 60), geoff = new DummyBean("Geoff", 70);


### PR DESCRIPTION
This PR updates all of the queue atoms/beans with a shortname for use with a currently under development QueueBeanFactory. It also restructures the *Process classes to remove boilerplate code from the concrete classes. Finally it makes changes to MonitorAtomProcess that fix the unit test for termination. As part of this, I re-structured MonitorAtomProcess so it's more like my other *Process classes; I'm happy to make changes to improve readability if felt necessary.