### PR TITLE
DAQ-661 - Combine multiple ROIs into one excluder

### DIFF
--- a/org.eclipse.scanning.points/scripts/jython_spg_interface.py
+++ b/org.eclipse.scanning.points/scripts/jython_spg_interface.py
@@ -335,8 +335,9 @@ class JRandomOffsetMutator(object):
         
 class JExcluder(object):
     
-    def __init__(self, roi, scannables):
-        self.py_excluder = ROIExcluder([roi.py_roi], scannables)
+    def __init__(self, rois, scannables):
+        py_rois = [roi.py_roi for roi in rois]
+        self.py_excluder = ROIExcluder(py_rois, scannables)
         logging.debug(self.py_excluder.to_dict())
         
 class JCircularROI(object):

--- a/org.eclipse.scanning.points/src/org/eclipse/scanning/points/AbstractScanPointIterator.java
+++ b/org.eclipse.scanning.points/src/org/eclipse/scanning/points/AbstractScanPointIterator.java
@@ -57,12 +57,14 @@ public abstract class AbstractScanPointIterator implements ScanPointIterator, Py
 			String[] regionAxes, PyObject[] mutators) {
 		JythonObjectFactory<PyObject> excluderFactory = ScanPointGeneratorFactory.JExcluderFactory();
 		JythonObjectFactory<ScanPointIterator> cpgFactory = ScanPointGeneratorFactory.JCompoundGeneratorFactory();
-		List<PyObject> pyRegions = Arrays.asList(regions).stream().map(r -> makePyRoi(r)).collect(Collectors.toList());
-		pyRegions = pyRegions.stream()
+		List<PyObject> pyRegions = Arrays.asList(regions)
+				.stream()
+				.map(r -> makePyRoi(r))
 				.filter(r -> r != null)
-				.map(r -> excluderFactory.createObject(r, new PyList(Arrays.asList(regionAxes))))
 				.collect(Collectors.toList());
-		ScanPointIterator cpgIterator = cpgFactory.createObject(iterators, pyRegions.toArray(), mutators);
+		PyObject excluder = excluderFactory.createObject(pyRegions.toArray(), new PyList(Arrays.asList(regionAxes)));
+		PyObject[] excluders = pyRegions.size() > 0 ? new PyObject[] {excluder} : new PyObject[] {};
+		ScanPointIterator cpgIterator = cpgFactory.createObject(iterators, excluders, mutators);
 		return cpgIterator;
 	}
 

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/epics/PVDataSerializationTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/epics/PVDataSerializationTest.java
@@ -1161,14 +1161,7 @@ public class PVDataSerializationTest {
 				createStructure();
 
 		// Excluders
-		PVStructure expectedExcluder1PVStructure = pvDataCreate.createPVStructure(expectedExcluderStructure);
-		PVStringArray scannables1Val = expectedExcluder1PVStructure.getSubField(PVStringArray.class, "axes");
-		String[] scannables1 = new String[] {"stage_x", "stage_y"};
-		scannables1Val.put(0, scannables1.length, scannables1, 0);
-
 		PVStructure expectedROI1PVStructure = pvDataCreate.createPVStructure(expectedCircularRoiStructure);
-		PVUnionArray rois1 = expectedExcluder1PVStructure.getSubField(PVUnionArray.class, "rois");
-
 		PVDoubleArray startVal1 = expectedROI1PVStructure.getSubField(PVDoubleArray.class, "start");
 		double[] start1 = new double[] {2, 1};
 		startVal1.put(0, start1.length, start1, 0);
@@ -1179,19 +1172,7 @@ public class PVDataSerializationTest {
 		PVDouble angleVal1 = expectedROI1PVStructure.getSubField(PVDouble.class, "angle");
 		angleVal1.put(Math.PI / 2.0);
 
-		PVUnion[] roi1Array = new PVUnion[1];
-		roi1Array[0] = pvDataCreate.createPVUnion(union);
-		roi1Array[0].set(expectedROI1PVStructure);
-		rois1.put(0, roi1Array.length, roi1Array, 0);
-
-		PVStructure expectedExcluder2PVStructure = pvDataCreate.createPVStructure(expectedExcluderStructure);
-		PVStringArray scannables2Val = expectedExcluder2PVStructure.getSubField(PVStringArray.class, "axes");
-		String[] scannables2 = new String[] {"stage_x", "stage_y"};
-		scannables2Val.put(0, scannables2.length, scannables2, 0);
-
 		PVStructure expectedROI2PVStructure = pvDataCreate.createPVStructure(expectedCircularRoiStructure);
-		PVUnionArray rois2 = expectedExcluder2PVStructure.getSubField(PVUnionArray.class, "rois");
-
 		PVDoubleArray startVal2 = expectedROI2PVStructure.getSubField(PVDoubleArray.class, "start");
 		double[] start2 = new double[] {-2, 2};
 		startVal2.put(0, start2.length, start2, 0);
@@ -1202,10 +1183,17 @@ public class PVDataSerializationTest {
 		PVDouble angleVal2 = expectedROI2PVStructure.getSubField(PVDouble.class, "angle");
 		angleVal2.put(0);
 
-		PVUnion[] roi2Array = new PVUnion[1];
-		roi2Array[0] = pvDataCreate.createPVUnion(union);
-		roi2Array[0].set(expectedROI2PVStructure);
-		rois2.put(0, roi2Array.length, roi2Array, 0);
+		PVStructure expectedExcluderPVStructure = pvDataCreate.createPVStructure(expectedExcluderStructure);
+		PVStringArray scannables1Val = expectedExcluderPVStructure.getSubField(PVStringArray.class, "axes");
+		String[] scannables1 = new String[] {"stage_x", "stage_y"};
+		scannables1Val.put(0, scannables1.length, scannables1, 0);
+		PVUnionArray rois = expectedExcluderPVStructure.getSubField(PVUnionArray.class, "rois");
+		PVUnion[] roiArray = new PVUnion[2];
+		roiArray[0] = pvDataCreate.createPVUnion(union);
+		roiArray[0].set(expectedROI1PVStructure);
+		roiArray[1] = pvDataCreate.createPVUnion(union);
+		roiArray[1].set(expectedROI2PVStructure);
+		rois.put(0, roiArray.length, roiArray, 0);
 
 		// Mutators
 		PVStructure expectedMutatorPVStructure = pvDataCreate.createPVStructure(expectedRandomOffsetMutatorStructure);
@@ -1261,11 +1249,9 @@ public class PVDataSerializationTest {
 		durationVal.put(1.5);
 		PVUnionArray excluders = expectedCompGenPVStructure.getSubField(PVUnionArray.class, "excluders");
 
-		PVUnion[] unionArray = new PVUnion[2];
+		PVUnion[] unionArray = new PVUnion[1];
 		unionArray[0] = pvDataCreate.createPVUnion(union);
-		unionArray[0].set(expectedExcluder1PVStructure);
-		unionArray[1] = pvDataCreate.createPVUnion(union);
-		unionArray[1].set(expectedExcluder2PVStructure);
+		unionArray[0].set(expectedExcluderPVStructure);
 
 		excluders.put(0, unionArray.length, unionArray, 0);
 

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/malcolm/real/ExampleMalcolmDeviceTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/malcolm/real/ExampleMalcolmDeviceTest.java
@@ -295,49 +295,36 @@ public class ExampleMalcolmDeviceTest {
 			unionArray[0] = pvu1;
 			configurePVStructure.getUnionArrayField("generator.generators").put(0, unionArray.length, unionArray, 0);
 
-			PVStructure expectedExcluder1PVStructure = PVDataFactory.getPVDataCreate().createPVStructure(excluderStructure);
-			PVStringArray scannables1Val = expectedExcluder1PVStructure.getSubField(PVStringArray.class, "axes");
-			String[] scannables1 = new String[] {"stage_x", "stage_y"};
-			scannables1Val.put(0, scannables1.length, scannables1, 0);
+			PVStructure expectedExcluderPVStructure = PVDataFactory.getPVDataCreate().createPVStructure(excluderStructure);
+			PVStringArray scannablesVal = expectedExcluderPVStructure.getSubField(PVStringArray.class, "axes");
+			String[] scannables = new String[] {"stage_x", "stage_y"};
+			scannablesVal.put(0, scannables.length, scannables, 0);
+			PVUnionArray rois = expectedExcluderPVStructure.getSubField(PVUnionArray.class, "rois");
 			
 			PVStructure expectedROIPVStructure1 = PVDataFactory.getPVDataCreate().createPVStructure(circularRoiStructure);
-			PVUnionArray rois1 = expectedExcluder1PVStructure.getSubField(PVUnionArray.class, "rois");
-
 			PVDoubleArray cr1CentreVal = expectedROIPVStructure1.getSubField(PVDoubleArray.class, "centre");
 			double[] cr1Centre = new double[] {0, 0};
 			cr1CentreVal.put(0, cr1Centre.length, cr1Centre, 0);
 			PVDouble radius1Val = expectedROIPVStructure1.getSubField(PVDouble.class, "radius");
 			radius1Val.put(2);
 
-			PVUnion[] roiArray1 = new PVUnion[1];
-			roiArray1[0] = PVDataFactory.getPVDataCreate().createPVUnion(union);
-			roiArray1[0].set(expectedROIPVStructure1);
-			rois1.put(0, roiArray1.length, roiArray1, 0);
-
-			PVStructure expectedExcluder2PVStructure = PVDataFactory.getPVDataCreate().createPVStructure(excluderStructure);
-			PVStringArray scannables2Val = expectedExcluder2PVStructure.getSubField(PVStringArray.class, "axes");
-			String[] scannables2 = new String[] {"stage_x", "stage_y"};
-			scannables2Val.put(0, scannables2.length, scannables2, 0);
-			
 			PVStructure expectedROIPVStructure2 = PVDataFactory.getPVDataCreate().createPVStructure(circularRoiStructure);
-			PVUnionArray rois2 = expectedExcluder2PVStructure.getSubField(PVUnionArray.class, "rois");
-
 			PVDoubleArray cr2CentreVal = expectedROIPVStructure2.getSubField(PVDoubleArray.class, "centre");
 			double[] cr2Centre = new double[] {-1, -2};
 			cr2CentreVal.put(0, cr2Centre.length, cr2Centre, 0);
 			PVDouble radius2Val = expectedROIPVStructure2.getSubField(PVDouble.class, "radius");
 			radius2Val.put(4);
 
-			PVUnion[] roiArray2 = new PVUnion[1];
-			roiArray2[0] = PVDataFactory.getPVDataCreate().createPVUnion(union);
-			roiArray2[0].set(expectedROIPVStructure2);
-			rois2.put(0, roiArray2.length, roiArray2, 0);
+			PVUnion[] roiArray = new PVUnion[2];
+			roiArray[0] = PVDataFactory.getPVDataCreate().createPVUnion(union);
+			roiArray[0].set(expectedROIPVStructure1);
+			roiArray[1] = PVDataFactory.getPVDataCreate().createPVUnion(union);
+			roiArray[1].set(expectedROIPVStructure2);
+			rois.put(0, roiArray.length, roiArray, 0);
 
-			PVUnion[] crUnionArray = new PVUnion[2];
+			PVUnion[] crUnionArray = new PVUnion[1];
 			crUnionArray[0] = PVDataFactory.getPVDataCreate().createPVUnion(union);
-			crUnionArray[0].set(expectedExcluder1PVStructure);
-			crUnionArray[1] = PVDataFactory.getPVDataCreate().createPVUnion(union);
-			crUnionArray[1].set(expectedExcluder2PVStructure);
+			crUnionArray[0].set(expectedExcluderPVStructure);
 
 			configurePVStructure.getUnionArrayField("generator.excluders").put(0, crUnionArray.length, crUnionArray, 0);
 


### PR DESCRIPTION
Putting multiple regions into one excluder will consider the union of
the regions, rather than the intersection, when calculating scan
points. This is the behaviour "expected" of the GUI.

We can always add a means to "intersect" multiple regions later.

Note that an excluder can currently only cover two axes - so two
regions that cover different axes must necessarily have their
intersection considered, not their union.

Signed-off-by: Charles Mita <charles.mita@diamond.ac.uk>