### PR TITLE
[DAQ-659] use MalcolmMessage enum instead of inspecting stack trace

### DIFF
--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/malcolm/connector/MalcolmMethod.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/malcolm/connector/MalcolmMethod.java
@@ -1,0 +1,29 @@
+package org.eclipse.scanning.api.malcolm.connector;
+
+import org.eclipse.scanning.api.malcolm.message.MalcolmMessage;
+
+/**
+ * An enumeration of the malcolm methods that can be set in a {@link MalcolmMessage}. 
+ * 
+ * @author Matthew Dickie
+ */
+public enum MalcolmMethod {
+	
+	ABORT,
+	CONFIGURE,
+	DISABLE,
+	PAUSE,
+	RESET,
+	RESUME,
+	RUN,
+	VALIDATE;
+	
+	/**
+	 * Returns the name of this message in lower case, as expected by the malcolm device
+	 * over a communication channel.
+	 * @see java.lang.Enum#toString()
+	 */
+	public String toString() {
+		return name().toLowerCase();
+	}
+}

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/malcolm/connector/MessageGenerator.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/malcolm/connector/MessageGenerator.java
@@ -26,13 +26,13 @@ import org.eclipse.scanning.api.malcolm.MalcolmDeviceException;
 public interface MessageGenerator<T> {
 
 	/**
-	 * Automatically generates a call for a given method by using the method name from the stack.
+	 * Automatically generates a call for a given method
 	 * 
-	 * @param stackTrace
+	 * @param method
 	 * @param running
 	 * @throws MalcolmDeviceException
 	 */
-	T call(StackTraceElement[] stackTrace, DeviceState... states) throws MalcolmDeviceException;
+	T call(MalcolmMethod method, DeviceState... states) throws MalcolmDeviceException;
 	
 	/**
 	 * Create a get message
@@ -43,12 +43,12 @@ public interface MessageGenerator<T> {
 
 	/**
 	 * Create a call message
-	 * @param methodName
+	 * @param method
 	 * @param params
 	 * @return
 	 * @throws MalcolmDeviceException
 	 */
-	T createCallMessage(String methodName, Object params) throws MalcolmDeviceException;
+	T createCallMessage(MalcolmMethod method, Object params) throws MalcolmDeviceException;
 
 	
     /**

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/malcolm/message/MalcolmMessage.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/malcolm/message/MalcolmMessage.java
@@ -13,6 +13,8 @@ package org.eclipse.scanning.api.malcolm.message;
 
 import java.util.Map;
 
+import org.eclipse.scanning.api.malcolm.connector.MalcolmMethod;
+
 /**
  * Class used to define malcolm object which 
  * sends information to the server.
@@ -32,7 +34,7 @@ public class MalcolmMessage {
 	private long   id;
 	private String param;
 	private String endpoint;
-	private String method;
+	private MalcolmMethod method;
 	private String message;
 	private Object arguments;
 	private Object value;
@@ -144,10 +146,10 @@ public class MalcolmMessage {
 		this.value = val;
 	}
 	
-	public String getMethod() {
+	public MalcolmMethod getMethod() {
 		return method;
 	}
-	public void setMethod(String method) {
+	public void setMethod(MalcolmMethod method) {
 		this.method = method;
 	}
 	public String getMessage() {

--- a/org.eclipse.scanning.connector.epics/src/org/eclipse/scanning/connector/epics/EpicsV4MalcolmMessageGenerator.java
+++ b/org.eclipse.scanning.connector.epics/src/org/eclipse/scanning/connector/epics/EpicsV4MalcolmMessageGenerator.java
@@ -15,6 +15,7 @@ import org.eclipse.scanning.api.event.scan.DeviceState;
 import org.eclipse.scanning.api.malcolm.IMalcolmDevice;
 import org.eclipse.scanning.api.malcolm.MalcolmDeviceException;
 import org.eclipse.scanning.api.malcolm.connector.IMalcolmConnectorService;
+import org.eclipse.scanning.api.malcolm.connector.MalcolmMethod;
 import org.eclipse.scanning.api.malcolm.connector.MessageGenerator;
 import org.eclipse.scanning.api.malcolm.message.MalcolmMessage;
 import org.eclipse.scanning.api.malcolm.message.Type;
@@ -70,41 +71,26 @@ class EpicsV4MalcolmMessageGenerator implements MessageGenerator<MalcolmMessage>
 		return msg;
 	}
 	
-	private MalcolmMessage createCallMessage(final String methodName) throws MalcolmDeviceException {
+	private MalcolmMessage createCallMessage(final MalcolmMethod method) throws MalcolmDeviceException {
 		final MalcolmMessage msg = createMalcolmMessage();
 		msg.setType(Type.CALL);
-		msg.setMethod(methodName); 
+		msg.setMethod(method); 
 		return msg;
 	}
 	@Override
-	public MalcolmMessage createCallMessage(final String methodName, Object arg) throws MalcolmDeviceException {
-		final MalcolmMessage msg = createCallMessage(methodName);
+	public MalcolmMessage createCallMessage(MalcolmMethod method, Object arg) throws MalcolmDeviceException {
+		final MalcolmMessage msg = createCallMessage(method);
 		msg.setArguments(arg);
 		return msg;
 	}
 	
 	@Override
-	public MalcolmMessage call(StackTraceElement[] stackTrace, DeviceState... latches) throws MalcolmDeviceException {
-		final MalcolmMessage msg   = createCallMessage(getMethodName(stackTrace));
+	public MalcolmMessage call(MalcolmMethod method, DeviceState... latches) throws MalcolmDeviceException {
+		final MalcolmMessage msg   = createCallMessage(method);
 		final MalcolmMessage reply = service.send(device, msg);
 		// TODO What about state changes? Should we block?
 		//if (latches!=null) latch(latches);
 		return reply;
 	}
-	
-	private static final String getMethodName(StackTraceElement ste[]) {
-	    String methodName = "";
-	    boolean flag = false;
-	   
-	    for (StackTraceElement s : ste) {
-	        if (flag) {
-	            methodName = s.getMethodName();
-	            break;
-	        }
-	        flag = s.getMethodName().equals("getStackTrace");
-	    }
-	    return methodName;
-	}
-	
 
 }

--- a/org.eclipse.scanning.connector.epics/src/org/eclipse/scanning/connector/epics/custommarshallers/MalcolmMessageSerialiser.java
+++ b/org.eclipse.scanning.connector.epics/src/org/eclipse/scanning/connector/epics/custommarshallers/MalcolmMessageSerialiser.java
@@ -98,7 +98,7 @@ public class MalcolmMessageSerialiser implements IPVStructureSerialiser<MalcolmM
 			PVString method = methodName.getSubField(PVString.class, "method");
 			PVStructure parameters = pvStructure.getStructureField("parameters");
 			
-			method.put(msg.getMethod());
+			method.put(msg.getMethod().toString());
 			
 			if (msg.getArguments() != null) {
 				if (msg.getArguments() instanceof Map) {

--- a/org.eclipse.scanning.malcolm.core/src/org/eclipse/scanning/malcolm/core/AbstractMalcolmDevice.java
+++ b/org.eclipse.scanning.malcolm.core/src/org/eclipse/scanning/malcolm/core/AbstractMalcolmDevice.java
@@ -37,6 +37,7 @@ import org.eclipse.scanning.api.event.scan.DeviceState;
 import org.eclipse.scanning.api.malcolm.IMalcolmDevice;
 import org.eclipse.scanning.api.malcolm.MalcolmDeviceException;
 import org.eclipse.scanning.api.malcolm.connector.IMalcolmConnectorService;
+import org.eclipse.scanning.api.malcolm.connector.MalcolmMethod;
 import org.eclipse.scanning.api.malcolm.connector.MessageGenerator;
 import org.eclipse.scanning.api.malcolm.event.IMalcolmListener;
 import org.eclipse.scanning.api.malcolm.event.MalcolmEventBean;
@@ -179,8 +180,8 @@ public abstract class AbstractMalcolmDevice<M extends IMalcolmModel> extends Abs
 	protected MalcolmMessage createGetMessage(String endpoint) throws MalcolmDeviceException {
 		return connectionDelegate.createGetMessage(endpoint);
 	}
-	protected MalcolmMessage createCallMessage(String endpoint, Object params) throws MalcolmDeviceException {
-		return connectionDelegate.createCallMessage(endpoint, params);
+	protected MalcolmMessage createCallMessage(MalcolmMethod method, Object params) throws MalcolmDeviceException {
+		return connectionDelegate.createCallMessage(method, params);
 	}
 	protected MalcolmMessage createSubscribeMessage(String endpoint) throws MalcolmDeviceException {
 		return connectionDelegate.createSubscribeMessage(endpoint);
@@ -212,8 +213,9 @@ public abstract class AbstractMalcolmDevice<M extends IMalcolmModel> extends Abs
 	protected MalcolmMessage send(MalcolmMessage message, long timeout) throws MalcolmDeviceException, InterruptedException, ExecutionException, TimeoutException {
 	    return asynch(()->connector.send(this, message), timeout);
 	}
-	protected MalcolmMessage call(StackTraceElement[] trace, long timeout, DeviceState... states) throws MalcolmDeviceException, InterruptedException, ExecutionException, TimeoutException {
-	    return asynch(()->connectionDelegate.call(trace, states), timeout);
+	
+	protected MalcolmMessage call(MalcolmMethod method, long timeout, DeviceState... states) throws MalcolmDeviceException, InterruptedException, ExecutionException, TimeoutException {
+	    return asynch(()->connectionDelegate.call(method, states), timeout);
 	}
 	
 	/**

--- a/org.eclipse.scanning.malcolm.core/src/org/eclipse/scanning/malcolm/core/MalcolmDevice.java
+++ b/org.eclipse.scanning.malcolm.core/src/org/eclipse/scanning/malcolm/core/MalcolmDevice.java
@@ -36,6 +36,7 @@ import org.eclipse.scanning.api.malcolm.attributes.IDeviceAttribute;
 import org.eclipse.scanning.api.malcolm.attributes.MalcolmAttribute;
 import org.eclipse.scanning.api.malcolm.attributes.NumberAttribute;
 import org.eclipse.scanning.api.malcolm.connector.IMalcolmConnectorService;
+import org.eclipse.scanning.api.malcolm.connector.MalcolmMethod;
 import org.eclipse.scanning.api.malcolm.event.IMalcolmListener;
 import org.eclipse.scanning.api.malcolm.event.MalcolmEvent;
 import org.eclipse.scanning.api.malcolm.event.MalcolmEventBean;
@@ -380,7 +381,7 @@ public class MalcolmDevice<M extends MalcolmModel> extends AbstractMalcolmDevice
 		final EpicsMalcolmModel epicsModel = createEpicsMalcolmModel(params);
 		MalcolmMessage reply = null;
 		try {
-			final MalcolmMessage msg   = createCallMessage("validate", epicsModel);
+			final MalcolmMessage msg   = createCallMessage(MalcolmMethod.VALIDATE, epicsModel);
 			reply = send(msg, getTimeout());
 			if (reply.getType()==Type.ERROR) {
 				throw new ValidationException("Error from Malcolm Device Connection: " + reply.getMessage());
@@ -404,7 +405,7 @@ public class MalcolmDevice<M extends MalcolmModel> extends AbstractMalcolmDevice
 		}
 		
 		final EpicsMalcolmModel epicsModel = createEpicsMalcolmModel(model);
-		final MalcolmMessage msg   = createCallMessage("configure", epicsModel);
+		final MalcolmMessage msg   = createCallMessage(MalcolmMethod.CONFIGURE, epicsModel);
 		MalcolmMessage reply = wrap(()->send(msg, getConfigTimeout()));
 		if (reply.getType() == Type.ERROR) {
 			throw new MalcolmDeviceException("Error from Malcolm Device Connection: " + reply.getMessage());
@@ -439,7 +440,7 @@ public class MalcolmDevice<M extends MalcolmModel> extends AbstractMalcolmDevice
 	
 	@Override
 	public void run(IPosition pos) throws MalcolmDeviceException, InterruptedException, ExecutionException, TimeoutException {
-		MalcolmMessage reply = call(Thread.currentThread().getStackTrace(), getRunTimeout(), DeviceState.RUNNING);
+		MalcolmMessage reply = call(MalcolmMethod.RUN, getRunTimeout(), DeviceState.RUNNING);
 		if (reply.getType()==Type.ERROR) {
 			throw new MalcolmDeviceException("Error from Malcolm Device Connection: " + reply.getMessage());
 		}
@@ -449,7 +450,7 @@ public class MalcolmDevice<M extends MalcolmModel> extends AbstractMalcolmDevice
 	public void seek(int stepNumber) throws MalcolmDeviceException {
 		LinkedHashMap<String, Integer> seekParameters = new LinkedHashMap<>();
 		seekParameters.put(CURRENT_STEP_ENDPOINT, stepNumber);
-		final MalcolmMessage msg   = createCallMessage("pause", seekParameters);
+		final MalcolmMessage msg   = createCallMessage(MalcolmMethod.PAUSE, seekParameters);
 		final MalcolmMessage reply = wrap(()->send(msg, getConfigTimeout()));
 		if (reply.getType()==Type.ERROR) {
 			throw new MalcolmDeviceException("Error from Malcolm Device Connection: " + reply.getMessage());
@@ -458,7 +459,7 @@ public class MalcolmDevice<M extends MalcolmModel> extends AbstractMalcolmDevice
 
 	@Override
 	public void abort() throws MalcolmDeviceException {
-		MalcolmMessage reply = wrap(()->call(Thread.currentThread().getStackTrace(), getTimeout()));
+		MalcolmMessage reply = wrap(()->call(MalcolmMethod.ABORT, getTimeout()));
 		if (reply.getType()==Type.ERROR) {
 			throw new MalcolmDeviceException("Error from Malcolm Device Connection: " + reply.getMessage());
 		}
@@ -466,7 +467,7 @@ public class MalcolmDevice<M extends MalcolmModel> extends AbstractMalcolmDevice
 
 	@Override
 	public void disable() throws MalcolmDeviceException {
-		MalcolmMessage reply = wrap(()->call(Thread.currentThread().getStackTrace(), getTimeout()));
+		MalcolmMessage reply = wrap(()->call(MalcolmMethod.DISABLE, getTimeout()));
 		if (reply.getType()==Type.ERROR) {
 			throw new MalcolmDeviceException("Error from Malcolm Device Connection: " + reply.getMessage());
 		}
@@ -474,7 +475,7 @@ public class MalcolmDevice<M extends MalcolmModel> extends AbstractMalcolmDevice
 
 	@Override
 	public void reset() throws MalcolmDeviceException {
-		MalcolmMessage reply = wrap(()->call(Thread.currentThread().getStackTrace(), getTimeout()));
+		MalcolmMessage reply = wrap(()->call(MalcolmMethod.RESET, getTimeout()));
 		if (reply.getType()==Type.ERROR) {
 			throw new MalcolmDeviceException("Error from Malcolm Device Connection: " + reply.getMessage());
 		}
@@ -482,7 +483,7 @@ public class MalcolmDevice<M extends MalcolmModel> extends AbstractMalcolmDevice
 
 	@Override
 	public void pause() throws MalcolmDeviceException {
-		MalcolmMessage reply = wrap(()->call(Thread.currentThread().getStackTrace(), getConfigTimeout()));
+		MalcolmMessage reply = wrap(()->call(MalcolmMethod.PAUSE, getConfigTimeout()));
 		if (reply.getType()==Type.ERROR) {
 			throw new MalcolmDeviceException("Error from Malcolm Device Connection: " + reply.getMessage());
 		}
@@ -490,7 +491,7 @@ public class MalcolmDevice<M extends MalcolmModel> extends AbstractMalcolmDevice
 	
 	@Override
 	public void resume() throws MalcolmDeviceException {
-		MalcolmMessage reply = wrap(()->call(Thread.currentThread().getStackTrace(), getTimeout()));
+		MalcolmMessage reply = wrap(()->call(MalcolmMethod.RESUME, getTimeout()));
 		if (reply.getType()==Type.ERROR) {
 			throw new MalcolmDeviceException("Error from Malcolm Device Connection: " + reply.getMessage());
 		}


### PR DESCRIPTION
Signed-off-by: Matthew Dickie <matthew.dickie@diamond.ac.uk>