### PR TITLE
remove workaround for scalar datasets when asserting datasets equal

### DIFF
--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/nexus/NexusAssert.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/nexus/NexusAssert.java
@@ -414,10 +414,6 @@ public class NexusAssert {
 		assertEquals(path, expectedDataset.getElementClass(), actualDataset.getElementClass());
 		assertEquals(path, expectedDataset.getElementsPerItem(), actualDataset.getElementsPerItem());
 		assertEquals(path, expectedDataset.getSize(), actualDataset.getSize());
-		if (expectedDataset.getSize() == 1 && expectedDataset.getRank() == 1 && actualDataset.getRank() == 0) {
-			// TODO fix examples now that we can save scalar (or zero-ranked) datasets
-			actualDataset.setShape(1);
-		}
 		assertEquals(path, expectedDataset.getRank(), actualDataset.getRank());
 		assertArrayEquals(path, expectedDataset.getShape(), actualDataset.getShape());
 		assertDatasetDataEqual(path, expectedDataset, actualDataset);


### PR DESCRIPTION
Nexus now writes scalar datasets correctly. Previously they were written
as datasets of rank 1 and size 1. So we can remove the workaround that
allows this case when comparing the nexus tree loaded from the file
with the original.

Signed-off-by: Matthew Dickie <matthew.dickie@diamond.ac.uk>