### PR TITLE
Queue spooler stub & ISampleInformationService update

### DIFF
--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/database/ISampleDescriptionService.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/database/ISampleDescriptionService.java
@@ -3,6 +3,9 @@ package org.eclipse.scanning.api.database;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.scanning.api.event.queues.models.ExperimentConfiguration;
+import org.eclipse.scanning.api.scan.models.ScanMetadata;
+
 /**
  * 
  * A Service for getting sample information.
@@ -12,6 +15,7 @@ import java.util.Map;
  * an IllegalArgumentException.
  * 
  * @author Matthew Gerring
+ * @author Michael Wharmby
  *
  */
 public interface ISampleDescriptionService {
@@ -29,6 +33,17 @@ public interface ISampleDescriptionService {
 	}
 	
 	/**
+	 * This method returns all the names of the experiments which are ready to 
+	 * run according to 'retrieveSamplesAssignedForProposal'.
+	 * @param proposalCode
+	 * @param proposalNumber
+	 * @return Map{sampleId -> sampleName}
+	 */
+	default Map<Long, String> getSampleIdNames(String proposalCode, long proposalNumber) {
+		throw new IllegalArgumentException("Method getSamples(...) not implemented!");
+	}
+	
+	/**
 	 * 
 	 * @param proposalCode
 	 * @param proposalNumber
@@ -36,6 +51,33 @@ public interface ISampleDescriptionService {
 	 * @return SampleInformation object or other composite representing the sample information
 	 */
 	default <T> T getSampleInformation(String proposalCode, long proposalNumber, long sampleId) {
+		throw new IllegalArgumentException("Method getSampleInformation(...) not implemented!");
+	}
+	/**
+	 * For a sample in a particular session (proposal code + proposal number) 
+	 * produce the configuration necessary to configure the experiment. This 
+	 * method reprocesses the response of the database into a concrete class 
+	 * rather than a generic.
+	 * @param proposalCode
+	 * @param proposalNumber
+	 * @param sampleId
+	 * @return {@link ExperimentConfiguration} object as an explicit type 
+	 *         rather than a generic.
+	 */
+	default ExperimentConfiguration generateExperimentConfiguration(String proposalCode, long proposalNumber, long sampleId) {
+		throw new IllegalArgumentException("Method getSampleInformation(...) not implemented!");
+	}
+	
+	/**
+	 * For a sample in a particular session (proposal code + proposal number) 
+	 * produce the metadata which should be passed into the NeXus file during 
+	 * the scan, which the user provided to the database. 
+	 * @param proposalCode
+	 * @param proposalNumber
+	 * @param sampleIds
+	 * @return List<{@link ScanMetadata}> to be passed into the NeXus file 
+	 */
+	default List<ScanMetadata> generateSampleScanMetadata(String proposalCode, long proposalNumber, long sampleIds) {
 		throw new IllegalArgumentException("Method getSampleInformation(...) not implemented!");
 	}
 	
@@ -47,6 +89,35 @@ public interface ISampleDescriptionService {
 	 * @return Map{sampleId->SampleInformation}
 	 */
 	default <T> Map<Long,T> getSampleInformation(String proposalCode, long proposalNumber, long... sampleIds) {
+		throw new IllegalArgumentException("Method getSampleInformation(...) not implemented!");
+	}
+	
+	/**
+	 * For a series of samples in a particular session (proposal code + 
+	 * proposal number) produce the configuration necessary to configure the 
+	 * experiment. This  method reprocesses the response of the database into 
+	 * a concrete class rather than a generic.
+	 * @param proposalCode
+	 * @param proposalNumber
+	 * @param sampleIds
+	 * @return Map{sampleId -> {@link ExperimentConfiguration}} with explicit 
+	 *         object types rather than a generic.
+	 */
+	default Map<Long, ExperimentConfiguration> generateAllExperimentConfiguration(String proposalCode, long proposalNumber, long... sampleIds) {
+		throw new IllegalArgumentException("Method getSampleInformation(...) not implemented!");
+	}
+	
+	/**
+	 * For a series of samples in a particular session (proposal code + 
+	 * proposal number) produce the metadata which should be passed into the 
+	 * NeXus file during the scan, which the user provided to the database. 
+	 * @param proposalCode
+	 * @param proposalNumber
+	 * @param sampleIds
+	 * @return Map{sampleId -> List<{@link ScanMetadata}> to be passed into 
+	 *         the NeXus file 
+	 */
+	default Map<Long, List<ScanMetadata>> generateAllScanMetadata(String proposalCode, long proposalNumber, long... sampleIds) {
 		throw new IllegalArgumentException("Method getSampleInformation(...) not implemented!");
 	}
 

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/queues/IQueueSpoolerService.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/queues/IQueueSpoolerService.java
@@ -1,0 +1,22 @@
+package org.eclipse.scanning.api.event.queues;
+
+import java.util.List;
+
+import org.eclipse.scanning.api.event.queues.models.QueueModelException;
+
+public interface IQueueSpoolerService {
+	
+	/**
+	 * 
+	 * @param sampleIds List<Long> of sampleIds
+	 * @throws QueueModelException if one or more sampleIds could not be submitted
+	 */
+	void submitExperiments(List<Long> sampleIds) throws QueueModelException;
+	
+	/**
+	 * 
+	 * @return
+	 */
+	IQueueBeanFactory getQueueBeanFactory();
+
+}

--- a/org.eclipse.scanning.event.queues.spooler/src/org/eclipse/scanning/event/queues/spooler/QueueSpoolerService.java
+++ b/org.eclipse.scanning.event.queues.spooler/src/org/eclipse/scanning/event/queues/spooler/QueueSpoolerService.java
@@ -1,0 +1,23 @@
+package org.eclipse.scanning.event.queues.spooler;
+
+import java.util.List;
+
+import org.eclipse.scanning.api.event.queues.IQueueBeanFactory;
+import org.eclipse.scanning.api.event.queues.IQueueSpoolerService;
+import org.eclipse.scanning.api.event.queues.models.QueueModelException;
+
+public class QueueSpoolerService implements IQueueSpoolerService {
+
+	@Override
+	public void submitExperiments(List<Long> sampleIds) throws QueueModelException {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public IQueueBeanFactory getQueueBeanFactory() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/QueueSpoolerServiceTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/QueueSpoolerServiceTest.java
@@ -1,0 +1,52 @@
+package org.eclipse.scanning.test.event.queues;
+
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.scanning.api.database.ISampleDescriptionService;
+import org.eclipse.scanning.api.event.queues.IQueueSpoolerService;
+import org.eclipse.scanning.api.event.queues.models.QueueModelException;
+import org.eclipse.scanning.event.queues.spooler.QueueSpoolerService;
+import org.eclipse.scanning.test.event.queues.mocks.MockSampleDescriptionService;
+import org.junit.Before;
+import org.junit.Test;
+
+public class QueueSpoolerServiceTest {
+	
+	@Before
+	public void setUp() {
+		ISampleDescriptionService samServ = new MockSampleDescriptionService();
+		((MockSampleDescriptionService)samServ).setSampleIdNames(makeFakeExperimentIdNames());
+	}
+	
+	private Map<Long, String> makeFakeExperimentIdNames() {
+		Map<Long, String> fakeExperIdNames = new HashMap<>();
+		fakeExperIdNames.put(3245L, "XPDF Test1");
+		fakeExperIdNames.put(5324L, "XPDF Test2");
+		fakeExperIdNames.put(321345L, "XPDF Test5");
+		fakeExperIdNames.put(95222L, "XPDF testgg");
+		return fakeExperIdNames;
+	}
+	
+	@Test
+	public void testSubmitExperiments() throws QueueModelException {
+		IQueueSpoolerService qss = new QueueSpoolerService();
+		
+		try {
+			List<Long> wrongIds = Arrays.asList(2L, 6L, 6443L);
+			qss.submitExperiments(wrongIds);
+			fail("Should not be able to submit IDs that are known to the sample information service");
+		} catch (QueueModelException qme) {
+			//Expected. We don't allow wrong IDs to be submitted
+		}
+		
+		List<Long> idsToSubmit = Arrays.asList(3245L, 95222L, 321345L);
+		qss.submitExperiments(idsToSubmit);
+		
+	}
+
+}

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/mocks/MockSampleDescriptionService.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/mocks/MockSampleDescriptionService.java
@@ -1,0 +1,50 @@
+package org.eclipse.scanning.test.event.queues.mocks;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.scanning.api.database.ISampleDescriptionService;
+import org.eclipse.scanning.api.event.queues.models.ExperimentConfiguration;
+import org.eclipse.scanning.api.scan.models.ScanMetadata;
+
+public class MockSampleDescriptionService implements ISampleDescriptionService {
+	
+	private Map<Long, String> sampleIDNames;
+
+	@Override
+	public Map<Long, String> getSampleIdNames(String proposalCode, long proposalNumber) {
+		return sampleIDNames;
+	}
+	
+	public void setSampleIdNames(Map<Long, String> sampleIdNames) {
+		this.sampleIDNames = sampleIdNames;
+	}
+
+	@Override
+	public ExperimentConfiguration generateExperimentConfiguration(String proposalCode, long proposalNumber,
+			long sampleId) {
+		// TODO Auto-generated method stub
+		return ISampleDescriptionService.super.generateExperimentConfiguration(proposalCode, proposalNumber, sampleId);
+	}
+
+	@Override
+	public List<ScanMetadata> generateSampleScanMetadata(String proposalCode, long proposalNumber, long sampleIds) {
+		// TODO Auto-generated method stub
+		return ISampleDescriptionService.super.generateSampleScanMetadata(proposalCode, proposalNumber, sampleIds);
+	}
+
+	@Override
+	public Map<Long, ExperimentConfiguration> generateAllExperimentConfiguration(String proposalCode,
+			long proposalNumber, long... sampleIds) {
+		// TODO Auto-generated method stub
+		return ISampleDescriptionService.super.generateAllExperimentConfiguration(proposalCode, proposalNumber, sampleIds);
+	}
+
+	@Override
+	public Map<Long, List<ScanMetadata>> generateAllScanMetadata(String proposalCode, long proposalNumber,
+			long... sampleIds) {
+		// TODO Auto-generated method stub
+		return ISampleDescriptionService.super.generateAllScanMetadata(proposalCode, proposalNumber, sampleIds);
+	}
+
+}


### PR DESCRIPTION
Adds the IQueueSpoolerService and stub implementation, as well as test for Emilio. Changes ISampleInformationService to require returning of concrete classes so it can be used inside other parts of scanning.

Signed-off-by: Michael Wharmby <michael.wharmby@diamond.ac.uk>