### PR TITLE
Queue spooler stub & ISampleInformationService update (2)

### DIFF
--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/database/ISampleDescriptionService.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/database/ISampleDescriptionService.java
@@ -3,6 +3,9 @@ package org.eclipse.scanning.api.database;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.scanning.api.event.queues.models.ExperimentConfiguration;
+import org.eclipse.scanning.api.scan.models.ScanMetadata;
+
 /**
  * 
  * A Service for getting sample information.
@@ -12,6 +15,7 @@ import java.util.Map;
  * an IllegalArgumentException.
  * 
  * @author Matthew Gerring
+ * @author Michael Wharmby
  *
  */
 public interface ISampleDescriptionService {
@@ -29,6 +33,17 @@ public interface ISampleDescriptionService {
 	}
 	
 	/**
+	 * This method returns all the names of the experiments which are ready to 
+	 * run according to 'retrieveSamplesAssignedForProposal'.
+	 * @param proposalCode
+	 * @param proposalNumber
+	 * @return Map{sampleId -> sampleName}
+	 */
+	default Map<Long, String> getSampleIdNames(String proposalCode, long proposalNumber) {
+		throw new IllegalArgumentException("Method getSamples(...) not implemented!");
+	}
+	
+	/**
 	 * 
 	 * @param proposalCode
 	 * @param proposalNumber
@@ -36,6 +51,33 @@ public interface ISampleDescriptionService {
 	 * @return SampleInformation object or other composite representing the sample information
 	 */
 	default <T> T getSampleInformation(String proposalCode, long proposalNumber, long sampleId) {
+		throw new IllegalArgumentException("Method getSampleInformation(...) not implemented!");
+	}
+	/**
+	 * For a sample in a particular session (proposal code + proposal number) 
+	 * produce the configuration necessary to configure the experiment. This 
+	 * method reprocesses the response of the database into a concrete class 
+	 * rather than a generic.
+	 * @param proposalCode
+	 * @param proposalNumber
+	 * @param sampleId
+	 * @return {@link ExperimentConfiguration} object as an explicit type 
+	 *         rather than a generic.
+	 */
+	default ExperimentConfiguration generateExperimentConfiguration(String proposalCode, long proposalNumber, long sampleId) {
+		throw new IllegalArgumentException("Method getSampleInformation(...) not implemented!");
+	}
+	
+	/**
+	 * For a sample in a particular session (proposal code + proposal number) 
+	 * produce the metadata which should be passed into the NeXus file during 
+	 * the scan, which the user provided to the database. 
+	 * @param proposalCode
+	 * @param proposalNumber
+	 * @param sampleIds
+	 * @return List<{@link ScanMetadata}> to be passed into the NeXus file 
+	 */
+	default List<ScanMetadata> generateSampleScanMetadata(String proposalCode, long proposalNumber, long sampleIds) {
 		throw new IllegalArgumentException("Method getSampleInformation(...) not implemented!");
 	}
 	
@@ -47,6 +89,35 @@ public interface ISampleDescriptionService {
 	 * @return Map{sampleId->SampleInformation}
 	 */
 	default <T> Map<Long,T> getSampleInformation(String proposalCode, long proposalNumber, long... sampleIds) {
+		throw new IllegalArgumentException("Method getSampleInformation(...) not implemented!");
+	}
+	
+	/**
+	 * For a series of samples in a particular session (proposal code + 
+	 * proposal number) produce the configuration necessary to configure the 
+	 * experiment. This  method reprocesses the response of the database into 
+	 * a concrete class rather than a generic.
+	 * @param proposalCode
+	 * @param proposalNumber
+	 * @param sampleIds
+	 * @return Map{sampleId -> {@link ExperimentConfiguration}} with explicit 
+	 *         object types rather than a generic.
+	 */
+	default Map<Long, ExperimentConfiguration> generateAllExperimentConfiguration(String proposalCode, long proposalNumber, long... sampleIds) {
+		throw new IllegalArgumentException("Method getSampleInformation(...) not implemented!");
+	}
+	
+	/**
+	 * For a series of samples in a particular session (proposal code + 
+	 * proposal number) produce the metadata which should be passed into the 
+	 * NeXus file during the scan, which the user provided to the database. 
+	 * @param proposalCode
+	 * @param proposalNumber
+	 * @param sampleIds
+	 * @return Map{sampleId -> List<{@link ScanMetadata}> to be passed into 
+	 *         the NeXus file 
+	 */
+	default Map<Long, List<ScanMetadata>> generateAllScanMetadata(String proposalCode, long proposalNumber, long... sampleIds) {
 		throw new IllegalArgumentException("Method getSampleInformation(...) not implemented!");
 	}
 

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/queues/IQueueSpoolerService.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/queues/IQueueSpoolerService.java
@@ -1,0 +1,92 @@
+package org.eclipse.scanning.api.event.queues;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.scanning.api.database.ISampleDescriptionService;
+import org.eclipse.scanning.api.event.EventException;
+import org.eclipse.scanning.api.event.queues.beans.TaskBean;
+import org.eclipse.scanning.api.event.queues.models.ExperimentConfiguration;
+import org.eclipse.scanning.api.event.queues.models.QueueModelException;
+import org.eclipse.scanning.api.event.scan.ScanRequest;
+import org.eclipse.scanning.api.scan.models.ScanMetadata;
+
+public interface IQueueSpoolerService {
+	
+	/**
+	 * Generate a {@link TaskBean} from data supplied from the 
+	 * {@link ISampleDescriptionService} and submit it to the job-queue of the 
+	 * {@link IQueueService}. This method also checks that the bean is ready 
+	 * to be submitted before hand.
+	 * @param proposalCode String group code of proposal (e.g. CM)
+	 * @param proposalNumber long ID number of proposal
+	 * @param sampleIdsList List<Long> of sampleIds
+	 * @throws QueueModelException if a sampleID is not ready or could not be 
+	 *         assembled into a bean
+	 * @throws EventException if submission of the bean for a sampleID failed
+	 */
+	default void submitExperiments(String proposalCode, long proposalNumber, List<Long> sampleIdsList) throws QueueModelException, EventException {
+		long[] sampleIds = new long[sampleIdsList.size()];
+		for (int i = 0; i < sampleIdsList.size(); i++) {
+			long id = sampleIdsList.get(i);
+			if (!isExperimentReady(proposalCode, proposalNumber, id)) {
+				String missingExpName = getSampleService().getSampleIdNames(proposalCode, proposalNumber).get(id);
+				throw new QueueModelException("Cannot submit experiment "+missingExpName+" (ID="+id+"). Database indicates it is not ready");
+			}
+			sampleIds[i] = id;
+		}
+		
+		Map<Long, ExperimentConfiguration> allConfigs = getSampleService().generateAllExperimentConfiguration(proposalCode, proposalNumber, sampleIds);
+		Map<Long, List<ScanMetadata>> allMetadata = getSampleService().generateAllScanMetadata(proposalCode, proposalNumber, sampleIds);
+		for (long id : sampleIds) {
+			TaskBean task = createBeansForExperiment(allConfigs.get(id), allMetadata.get(id));
+			doSubmission(task);
+		}
+		
+	}
+	
+	/**
+	 * Determine whether an experiment with a given ID is marked ready to 
+	 * submit according to, for example, the {@link ISampleDescriptionService}.
+	 * @param proposalCode
+	 * @param proposalNumber
+	 * @param id
+	 * @return true if the experiment is ready
+	 */
+	boolean isExperimentReady(String proposalCode, long proposalNumber, long sampleId);
+	
+	/**
+	 * Use the {@link IQueueBeanFactory} to generate a new {@link TaskBean} 
+	 * which contains a full description of the planned experiment.
+	 * @param config {@link ExperimentConfiguration} to configure 
+	 *        {@link ScanRequest}
+	 * @param metadata List<{@link ScanMetadata}> to be included in the NeXus 
+	 *        file from the scan
+	 * @return {@link TaskBean} to be submitted
+	 * @throws QueueModelException if construction of the bean failed
+	 */
+	TaskBean createBeansForExperiment(ExperimentConfiguration config, List<ScanMetadata> metadata) throws QueueModelException;
+	
+	/**
+	 * Submit a {@link TaskBean} to the job-queue of {@link IQueueService}. 
+	 * The {@link IQueueControllerService} provides methods to do this.
+	 * @param bean {@link TaskBean} to be submitted
+	 * @throws EventException if submission of the bean failed
+	 */
+	void doSubmission(TaskBean bean) throws EventException;
+	
+	/**
+	 * Return the {@link IQueueBeanFactory} used by this service to assemble 
+	 * beans.
+	 * @return {@link IQueueBeanFactory}
+	 */
+	IQueueBeanFactory getQueueBeanFactory();
+	
+	/**
+	 * Return the {@link ISampleDescriptionService} used by this service to 
+	 * get information about experiments from the database.
+	 * @return {@link ISampleDescriptionService}
+	 */
+	ISampleDescriptionService getSampleService();
+
+}

--- a/org.eclipse.scanning.event.queues.spooler/src/org/eclipse/scanning/event/queues/spooler/QueueSpoolerService.java
+++ b/org.eclipse.scanning.event.queues.spooler/src/org/eclipse/scanning/event/queues/spooler/QueueSpoolerService.java
@@ -1,0 +1,47 @@
+package org.eclipse.scanning.event.queues.spooler;
+
+import java.util.List;
+
+import org.eclipse.scanning.api.database.ISampleDescriptionService;
+import org.eclipse.scanning.api.event.EventException;
+import org.eclipse.scanning.api.event.queues.IQueueBeanFactory;
+import org.eclipse.scanning.api.event.queues.IQueueSpoolerService;
+import org.eclipse.scanning.api.event.queues.beans.TaskBean;
+import org.eclipse.scanning.api.event.queues.models.ExperimentConfiguration;
+import org.eclipse.scanning.api.event.queues.models.QueueModelException;
+import org.eclipse.scanning.api.scan.models.ScanMetadata;
+
+public class QueueSpoolerService implements IQueueSpoolerService {
+
+	@Override
+	public boolean isExperimentReady(String proposalCode, long proposalNumber, long sampleId) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public TaskBean createBeansForExperiment(ExperimentConfiguration config, List<ScanMetadata> metadata)
+			throws QueueModelException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void doSubmission(TaskBean bean) throws EventException {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public IQueueBeanFactory getQueueBeanFactory() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public ISampleDescriptionService getSampleService() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/QueueSpoolerServiceTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/QueueSpoolerServiceTest.java
@@ -1,0 +1,77 @@
+package org.eclipse.scanning.test.event.queues;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.scanning.api.database.ISampleDescriptionService;
+import org.eclipse.scanning.api.event.EventException;
+import org.eclipse.scanning.api.event.queues.IQueueSpoolerService;
+import org.eclipse.scanning.api.event.queues.beans.TaskBean;
+import org.eclipse.scanning.api.event.queues.models.QueueModelException;
+import org.eclipse.scanning.event.queues.spooler.QueueSpoolerService;
+import org.eclipse.scanning.test.event.queues.mocks.MockSampleDescriptionService;
+import org.junit.Before;
+import org.junit.Test;
+
+public class QueueSpoolerServiceTest {
+	
+	@Before
+	public void setUp() {
+		ISampleDescriptionService samServ = new MockSampleDescriptionService();
+		((MockSampleDescriptionService)samServ).setSampleIdNames(makeFakeExperimentIdNames());
+	}
+	
+	private Map<Long, String> makeFakeExperimentIdNames() {
+		Map<Long, String> fakeExperIdNames = new HashMap<>();
+		fakeExperIdNames.put(3245L, "XPDF Test1");
+		fakeExperIdNames.put(5324L, "XPDF Test2");
+		fakeExperIdNames.put(321345L, "XPDF Test5");
+		fakeExperIdNames.put(95222L, "XPDF testgg");
+		return fakeExperIdNames;
+	}
+	
+	@Test
+	public void testIsExperimentReady() {
+		IQueueSpoolerService qss = new QueueSpoolerService();
+		assertTrue("ID is not ready, even though it is in the list", qss.isExperimentReady("CM", 14451L, 3245L));
+		assertFalse("ID is ready, even though it doesn't exist", qss.isExperimentReady("CM", 14451L, 5L));
+	}
+	
+	@Test
+	public void testCreateBeans() throws QueueModelException {
+		IQueueSpoolerService qss = new QueueSpoolerService();
+		//FIXME Shouldn't the name of the task bean be the name of the experiment???
+		//TODO add scanmetadata
+		TaskBean tb = new TaskBean("testTb", "EXPNAME!", true);
+		qss.getQueueBeanFactory().registerTask(tb);
+		
+		TaskBean expectedTB = expectedTaskBean();
+		TaskBean madeTB = qss.createBeansForExperiment(null, null); //TODO replace null with metadatas!
+		if (!expectedTB.equals(madeTB)) {
+			//TODO How do they differ?
+		}
+	}
+	
+	@Test
+	public void testSubmission() throws EventException {
+		IQueueSpoolerService qss = new QueueSpoolerService();
+		
+		//TODO Set MockIQueueControllerService in ServicesHolder
+		TaskBean submitMe = expectedTaskBean();
+		qss.doSubmission(submitMe);
+		
+		//TODO Get submitted bean from MockQueueControllerService & compare to submitMe
+//		assertEquals("Submitted and original TaskBeans differ", submitMe, mockQCont.getSubmitted());
+	}
+	
+	private TaskBean expectedTaskBean() {
+		TaskBean expectedTB = new TaskBean("testTb", "Experiment test");
+		//TODO add configured beans!
+		
+		return expectedTB;
+	}
+
+}

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/mocks/MockSampleDescriptionService.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/mocks/MockSampleDescriptionService.java
@@ -1,0 +1,50 @@
+package org.eclipse.scanning.test.event.queues.mocks;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.scanning.api.database.ISampleDescriptionService;
+import org.eclipse.scanning.api.event.queues.models.ExperimentConfiguration;
+import org.eclipse.scanning.api.scan.models.ScanMetadata;
+
+public class MockSampleDescriptionService implements ISampleDescriptionService {
+	
+	private Map<Long, String> sampleIDNames;
+
+	@Override
+	public Map<Long, String> getSampleIdNames(String proposalCode, long proposalNumber) {
+		return sampleIDNames;
+	}
+	
+	public void setSampleIdNames(Map<Long, String> sampleIdNames) {
+		this.sampleIDNames = sampleIdNames;
+	}
+
+	@Override
+	public ExperimentConfiguration generateExperimentConfiguration(String proposalCode, long proposalNumber,
+			long sampleId) {
+		// TODO Auto-generated method stub
+		return ISampleDescriptionService.super.generateExperimentConfiguration(proposalCode, proposalNumber, sampleId);
+	}
+
+	@Override
+	public List<ScanMetadata> generateSampleScanMetadata(String proposalCode, long proposalNumber, long sampleIds) {
+		// TODO Auto-generated method stub
+		return ISampleDescriptionService.super.generateSampleScanMetadata(proposalCode, proposalNumber, sampleIds);
+	}
+
+	@Override
+	public Map<Long, ExperimentConfiguration> generateAllExperimentConfiguration(String proposalCode,
+			long proposalNumber, long... sampleIds) {
+		// TODO Auto-generated method stub
+		return ISampleDescriptionService.super.generateAllExperimentConfiguration(proposalCode, proposalNumber, sampleIds);
+	}
+
+	@Override
+	public Map<Long, List<ScanMetadata>> generateAllScanMetadata(String proposalCode, long proposalNumber,
+			long... sampleIds) {
+		// TODO Auto-generated method stub
+		return ISampleDescriptionService.super.generateAllScanMetadata(proposalCode, proposalNumber, sampleIds);
+	}
+
+}


### PR DESCRIPTION
A second attempt...

Adds the IQueueSpoolerService and stub implementation, as well as test for Emilio. Changes ISampleInformationService to require returning of concrete classes so it can be used inside other parts of scanning.

Signed-off-by: Michael Wharmby michael.wharmby@diamond.ac.uk