### PR TITLE
[DAQ-758] Correct calculation of device timeout

### DIFF
--- a/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/DeviceRunner.java
+++ b/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/DeviceRunner.java
@@ -77,11 +77,8 @@ class DeviceRunner extends LevelRunner<IRunnableDevice<?>> {
 			timeout = ((ITimeoutable)model).getTimeout();
 			if (timeout <= 0 && model instanceof IDetectorModel) {
 				IDetectorModel dmodel = (IDetectorModel)model;
-				timeout = Math.round(dmodel.getExposureTime() + 1);
+				timeout = (long) Math.ceil(dmodel.getExposureTime() + 1);
 			}
-		} else if (model instanceof IDetectorModel) {
-			IDetectorModel dmodel = (IDetectorModel)model;
-			timeout = (long)Math.ceil(dmodel.getExposureTime());
 		}
 		return timeout;
 	}


### PR DESCRIPTION
Modify DeviceRunner.getTimeout() so that, if no explicit timeout
is set for a detector, it is set to (exposure time + 1s), rounded up
(Math.ceil()), rather than (potentially rounded down (Math.round()).

Also remove the test for IDetectorModel, as this is an extension
of ITimeoutable, which is tested for above, so this code will never
be executed.

Signed-off-by: Anthony Hull <anthony.hull@diamond.ac.uk>