### PR TITLE
Make MultiStepComposite::updateUnits public

### DIFF
--- a/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/composites/MultiStepComposite.java
+++ b/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/composites/MultiStepComposite.java
@@ -83,7 +83,7 @@ public class MultiStepComposite extends Composite {
 
 	}
 	
-	protected boolean updateUnits(Object value) {
+	public boolean updateUnits(Object value) {
 		if (value==null) return false;
 		if (scannableConnectorService==null) return false;
 		try {


### PR DESCRIPTION
When the composite is fixed to a single scannable and the name combo is disabled
it would be nice to be able to call this to set the correct units.

Signed-off-by: Douglas Winter <douglas.winter@diamond.ac.uk>