### PR TITLE
[DAQ-760] set scannables in ScanModel so same objects are used throug…

### DIFF
--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/AnnotationManager.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/AnnotationManager.java
@@ -165,16 +165,17 @@ public class AnnotationManager {
 	 * 
 	 * If a device does not implement ILevel its level is assumed to be ILevel.MAXIMUM 
 	 * 
-	 * @param ds
+	 * @param devices the devices to add
 	 */
-	public void addDevices(Collection<?> ds) {
-		
-		if (ds == null)  throw new IllegalArgumentException("No devices specified!");
-		// Make a copy of it and sort it
-		List<Object> devices = new ArrayList<>(ds);
-		Collections.sort(devices, new LevelComparitor());
-		addOrderedDevices(devices);
+	public void addDevices(Collection<?> devices) {
+		if (devices != null && !devices.isEmpty()) {
+			// Make a copy of the list and sort it
+			List<Object> sortedDevices = new ArrayList<>(devices);
+			Collections.sort(sortedDevices, new LevelComparitor());
+			addOrderedDevices(sortedDevices);
+		}
 	}
+	
 	private void addOrderedDevices(Collection<Object> ds) {
 		for (Object object : ds) processAnnotations(object);
 	}

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/device/IScannableDeviceService.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/device/IScannableDeviceService.java
@@ -15,11 +15,14 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.scanning.api.AbstractScannable;
 import org.eclipse.scanning.api.IScannable;
 import org.eclipse.scanning.api.event.scan.DeviceInformation;
+import org.eclipse.scanning.api.points.IDeviceDependentIterable;
+import org.eclipse.scanning.api.points.IPosition;
 import org.eclipse.scanning.api.scan.ScanningException;
 
 /**
@@ -72,7 +75,50 @@ public interface IScannableDeviceService {
 	 * @throws ScanningException if no scannable with the given name could be found
 	 */
 	<T> IScannable<T> getScannable(String name) throws ScanningException;
-
+	
+	/**
+	 * Returns a list of the scannables for the given {@link Iterable} over {@link IPosition}s.
+	 * @param positionIterable an iterator over positions
+	 * @return list of scannables for the given position iterable
+	 * @throws ScanningException if one or more of the scannables cannot be found
+	 */
+	default List<IScannable<?>> getScannables(Iterable<IPosition> positionIterable) throws ScanningException {
+		List<String> names = null;
+		if (positionIterable instanceof IDeviceDependentIterable) {
+			names = ((IDeviceDependentIterable) positionIterable).getScannableNames();
+		}
+		if (names == null) {
+			names = positionIterable.iterator().next().getNames();
+		}
+		
+		return getScannables(names);
+	}
+	
+	/**
+	 * Returns a list of the scannables for the given {@link IPosition}s.
+	 * @param position an {@link IPosition}
+	 * @return list of scannables for the given position
+	 * @throws ScanningException if one or more of the scannables cannot be found
+	 */
+	default List<IScannable<?>> getScannables(IPosition position) throws ScanningException {
+		return getScannables(position.getNames());
+	}
+	
+	/**
+	 * Returns a list of the scannables with the given names
+	 * @param scannableNames a list of scannable names
+	 * @return list of scannables for the given names
+	 * @throws ScanningException if one or more of the scannables cannot be found
+	 */
+	default List<IScannable<?>> getScannables(List<String> scannableNames) throws ScanningException {
+		final List<IScannable<?>> scannables = new ArrayList<>(scannableNames.size());
+		for (String scannableName : scannableNames) {
+			scannables.add(getScannable(scannableName));
+		}
+		
+		return scannables;
+	}
+	
 	/**
 	 * Returns the set of global per-scan monitors that should be added to all scans.
 	 * This is used to support legacy (GDA8) spring configurations. Should not be called

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/scan/IScanService.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/scan/IScanService.java
@@ -27,7 +27,7 @@ public interface IScanService extends IRunnableDeviceService {
 
 	/**
 	 * Used to register a scan participant. Once registered any scan
-	 * created will use the particpant.
+	 * created will use the participant.
 	 * 
 	 * @param device
 	 */
@@ -36,14 +36,14 @@ public interface IScanService extends IRunnableDeviceService {
 	
 	/**
 	 * Used to remove a scan participant. Once registered any scan
-	 * created will use the particpant it must be removed to stop this.
+	 * created will use the participant it must be removed to stop this.
 	 * 
 	 * @param device
 	 */
 	void removeScanParticipant(Object device);
 
 	/**
-	 * The list of objects to be run as particpants with the scan.
+	 * The list of objects to be run as participants with the scan.
 	 * @return
 	 */
 	Collection<Object> getScanParticipants();

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/scan/event/IPositioner.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/scan/event/IPositioner.java
@@ -88,9 +88,8 @@ public interface IPositioner extends IPositionListenable {
 	 * to the NeXus file. Monitors are sorted into level with the scannbles of the current position.
      *
 	 * @param monitors
-	 * @throws ScanningException
 	 */
-	void setMonitors(List<IScannable<?>> monitors) throws ScanningException;
+	void setMonitors(List<IScannable<?>> monitors);
 
 	/**
 	 * Monitors are a set of scannables which will have setPosition(null, IPosition) called and
@@ -100,9 +99,10 @@ public interface IPositioner extends IPositionListenable {
 	 * to the NeXus file. Monitors are sorted into level with the scannbles of the current position.
      *
 	 * @param monitors
-	 * @throws ScanningException
 	 */
-	void setMonitors(IScannable<?>... monitors) throws ScanningException;
+	void setMonitors(IScannable<?>... monitors);
+
+	void setScannables(List<IScannable<?>> scannables);
 
 	/**
 	 * Calling this method instructs the ExecutorService running the levels to shutdownNow().

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/scan/models/ScanModel.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/scan/models/ScanModel.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.eclipse.scanning.api.IScannable;
 import org.eclipse.scanning.api.device.IRunnableDevice;
+import org.eclipse.scanning.api.device.IScannableDeviceService;
 import org.eclipse.scanning.api.event.scan.ScanBean;
 import org.eclipse.scanning.api.points.IPosition;
 import org.eclipse.scanning.api.scan.ScanInformation;
@@ -61,10 +62,23 @@ public class ScanModel {
 	private ScanBean bean;
 	
 	/**
+	 * A list of scannables that may be set to a position
+	 * during the scan. They have {@code setPostition(pos, IPosition)}
+	 * called, where {@code pos} is non {@code null}, and should move
+	 * to this position and readout their new position.
+	 * Note that setting this field is optional, if {@code null} the
+	 * scan scannables will be retrieved from by {@link IScannableDeviceService}
+	 * by calling {@link IScannableDeviceService#getScannable(String)} for
+	 * each scannable name as returned by calling
+	 * {@code getPositionIterable().iterator().next().getNames()}.
+	 */
+	private List<IScannable<?>> scannables;
+	
+	/**
 	 * A set of scannables may optionally be 'readout' during
 	 * the scan without being told a value for their location.
-	 * They have setPosition(null, IPosition) called and should 
-	 * ensure that if their value is null, they do not move but
+	 * They have {@code setPosition(null, IPosition)} called and should 
+	 * ensure that if their value is {@code null}, they do not move but
 	 * still readout position
 	 */
 	private List<IScannable<?>> monitors;
@@ -175,7 +189,15 @@ public class ScanModel {
 	public void setPositionIterable(Iterable<IPosition> positionIterator) {
 		this.positionIterable = positionIterator;
 	}
-
+	
+	public List<IScannable<?>> getScannables() {
+		return scannables;
+	}
+	
+	public void setScannables(List<IScannable<?>> scannables) {
+		this.scannables = scannables;
+	}
+	
 	public List<IRunnableDevice<?>> getDetectors() {
 		if (detectors == null) {
 			return Collections.emptyList();
@@ -236,6 +258,9 @@ public class ScanModel {
 	}
 
 	public List<?> getAnnotationParticipants() {
+		if (annotationParticipants == null) {
+			return Collections.emptyList();
+		}
 		return annotationParticipants;
 	}
 

--- a/org.eclipse.scanning.event/src/org/eclipse/scanning/event/remote/_Positioner.java
+++ b/org.eclipse.scanning.event/src/org/eclipse/scanning/event/remote/_Positioner.java
@@ -98,14 +98,20 @@ class _Positioner extends AbstractRemoteService implements IPositioner {
 	}
 
 	@Override
-	public void setMonitors(List<IScannable<?>> monitors) throws ScanningException {
+	public void setMonitors(List<IScannable<?>> monitors) {
 		// TODO Use the _Scannable which is a remote scannable connection.
-		throw new ScanningException("Monitors may not be set on a remote positioner!");
+		throw new UnsupportedOperationException("Monitors may not be set on a remote positioner!");
 	}
 
 	@Override
-	public void setMonitors(IScannable<?>... monitors) throws ScanningException {
+	public void setMonitors(IScannable<?>... monitors) {
 		setMonitors(Arrays.asList(monitors));
+	}
+
+	@Override
+	public void setScannables(List<IScannable<?>> scannables) {
+		// TODO Use the _Scannable which is a remote scannable connection.
+		throw new UnsupportedOperationException("Scannables may not be set on a remote positioner!");
 	}
 
 	@Override

--- a/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/LevelRunner.java
+++ b/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/LevelRunner.java
@@ -68,7 +68,7 @@ abstract class LevelRunner<L extends ILevel> {
 	}
 
 	/**
-	 * Get a list of the objects which we would like to order by level.
+	 * Get a list of the objects which we would like to order by level
 	 * @return
 	 */
 	protected abstract Collection<L> getDevices() throws ScanningException ;
@@ -122,7 +122,7 @@ abstract class LevelRunner<L extends ILevel> {
 		boolean ok = pDelegate.firePositionWillPerform(loc);
         if (!ok) return false;
 		
-		Map<Integer, List<L>> positionMap = getLevelOrderedDevices(getDevices());
+		Map<Integer, List<L>> positionMap = getLevelOrderedDevices();
 		Map<Integer, AnnotationManager> managerMap = getLevelOrderedManagerMap(positionMap);
 		
 		try {
@@ -295,22 +295,23 @@ abstract class LevelRunner<L extends ILevel> {
 	 * @return
 	 * @throws ScanningException 
 	 */
-	protected Map<Integer, List<L>> getLevelOrderedDevices(final Collection<L> objects) throws ScanningException {
-		
-		if (objects==null) return Collections.emptyMap();
-		
+	protected Map<Integer, List<L>> getLevelOrderedDevices() throws ScanningException {
 		if (sortedObjects!=null && sortedObjects.get()!=null) return sortedObjects.get();
+
+		final Collection<L> devices = getDevices();
 		
-		final Map<Integer, List<L>> ret = new TreeMap<>();
-		for (L object : objects) {
+		if (devices == null) return Collections.emptyMap();
+		
+		final Map<Integer, List<L>> devicesByLevel = new TreeMap<>();
+		for (L object : devices) {
 			final int level = object.getLevel();
 		
-			if (!ret.containsKey(level)) ret.put(level, new ArrayList<L>(7));
-			ret.get(level).add(object);
+			if (!devicesByLevel.containsKey(level)) devicesByLevel.put(level, new ArrayList<L>(7));
+			devicesByLevel.get(level).add(object);
 		}
-		if (isLevelCachingAllowed()) sortedObjects = new SoftReference<Map>(ret);
+		if (isLevelCachingAllowed()) sortedObjects = new SoftReference<Map>(devicesByLevel);
 		
-		return ret;
+		return devicesByLevel;
 	}
 	
 	private SoftReference<Map> sortedManagers;

--- a/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/RunnableDeviceServiceImpl.java
+++ b/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/RunnableDeviceServiceImpl.java
@@ -425,7 +425,10 @@ public final class RunnableDeviceServiceImpl implements IRunnableDeviceService, 
 
 	@Override
 	public Collection<Object> getScanParticipants() {
-		return participants; // May be null
+		if (participants == null) {
+			return Collections.emptyList();
+		}
+		return participants;
 	}
 	
 	@SuppressWarnings("unchecked")

--- a/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/ScannablePositioner.java
+++ b/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/ScannablePositioner.java
@@ -36,6 +36,7 @@ final class ScannablePositioner extends LevelRunner<IScannable<?>> implements IP
 		
 	private IScannableDeviceService     connectorService;
 	private List<IScannable<?>>         monitors;
+	private List<IScannable<?>>         scannables;
 
 	ScannablePositioner(IScannableDeviceService service) {	
 		
@@ -100,12 +101,21 @@ final class ScannablePositioner extends LevelRunner<IScannable<?>> implements IP
 
 	@Override
 	protected Collection<IScannable<?>> getDevices() throws ScanningException {
-		Collection<String> names = position.getNames();
-		if (names==null) return null;
-		final List<IScannable<?>> ret = new ArrayList<>(names.size());
-		for (String name : position.getNames()) ret.add(connectorService.getScannable(name));
-		if (monitors!=null) for(IScannable<?> mon : monitors) ret.add(mon);
-		return ret;
+		final List<IScannable<?>> devices = new ArrayList<>();
+		
+		if (scannables == null) {
+			for (String name : position.getNames()) {
+				devices.add(connectorService.getScannable(name));
+			}
+		} else {
+			devices.addAll(scannables);
+		}
+		
+		if (monitors != null) {
+			devices.addAll(monitors);
+		}
+		
+		return devices;
 	}
 
 	@Override
@@ -181,6 +191,11 @@ final class ScannablePositioner extends LevelRunner<IScannable<?>> implements IP
 	
 	public void setMonitors(IScannable<?>... monitors) {
 		this.monitors = Arrays.asList(monitors);
+	}
+
+	@Override
+	public void setScannables(List<IScannable<?>> scannables) {
+		this.scannables = scannables;
 	}
 
 	@Override

--- a/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/nexus/NexusScanFileManager.java
+++ b/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/nexus/NexusScanFileManager.java
@@ -75,7 +75,6 @@ public class NexusScanFileManager implements INexusScanFileManager, IPositionLis
 	private static final Logger logger = LoggerFactory.getLogger(NexusScanFileManager.class);
 
 	private final AbstractRunnableDevice<ScanModel> scanDevice;
-	private final IScannableDeviceService scannableDeviceService;
 	private ScanModel model;
 	private NexusScanInfo scanInfo;
 	private NexusFileBuilder fileBuilder;
@@ -108,7 +107,6 @@ public class NexusScanFileManager implements INexusScanFileManager, IPositionLis
 	
 	public NexusScanFileManager(AbstractRunnableDevice<ScanModel> scanDevice) {
 		this.scanDevice = scanDevice;
-		this.scannableDeviceService = scanDevice.getConnectorService();
 	}
 	
 	/**
@@ -223,12 +221,10 @@ public class NexusScanFileManager implements INexusScanFileManager, IPositionLis
 	}
 
 	protected Map<ScanRole, Collection<INexusDevice<?>>> extractNexusDevices(ScanModel model) throws ScanningException {
-		final IPosition firstPosition = model.getPositionIterable().iterator().next();
-		final Collection<String> scannableNames = firstPosition.getNames();
 		
 		Map<ScanRole, Collection<INexusDevice<?>>> nexusDevices = new EnumMap<>(ScanRole.class);
 		nexusDevices.put(ScanRole.DETECTOR,  getNexusDevices(model.getDetectors()));
-		nexusDevices.put(ScanRole.SCANNABLE, getNexusScannables(scannableNames));
+		nexusDevices.put(ScanRole.SCANNABLE, getNexusDevices(model.getScannables()));
 		
 		if (model.getMonitors()!=null) {
 			Collection<IScannable<?>> perPoint = model.getMonitors().stream().filter(scannable -> scannable.getMonitorRole()==MonitorRole.PER_POINT).collect(Collectors.toList());
@@ -274,6 +270,8 @@ public class NexusScanFileManager implements INexusScanFileManager, IPositionLis
 	 */
 	@SuppressWarnings("deprecation")
 	private void addLegacyPerScanMonitors(ScanModel model, Collection<String> scannableNames) throws ScanningException {
+		IScannableDeviceService scannableDeviceService = scanDevice.getConnectorService();
+		
 		// build up the set of all metadata scannables
 		final Set<String> perScanMonitorNames = new HashSet<>();
 		
@@ -324,7 +322,7 @@ public class NexusScanFileManager implements INexusScanFileManager, IPositionLis
 	private IScannable<?> getPerScanMonitor(String monitorName) {
 		IScannable<?> scannable = null;
 		try {
-			scannable = scannableDeviceService.getScannable(monitorName);
+			scannable = scanDevice.getConnectorService().getScannable(monitorName);
 		} catch (ScanningException e) {
 			logger.error("No such scannable ''{}''", monitorName);
 			return null;
@@ -469,35 +467,6 @@ public class NexusScanFileManager implements INexusScanFileManager, IPositionLis
 	private List<INexusDevice<?>> getNexusDevices(Collection<?> devices) {
 		return devices.stream().filter(d -> d instanceof INexusDevice<?>).map(
 				d -> (INexusDevice<?>) d).collect(Collectors.toList());
-	}
-	
-	protected Collection<INexusDevice<?>> getNexusScannables(Collection<String> scannableNames) throws ScanningException {
-		try {
-			return scannableNames.stream().map(name -> getNexusScannable(name)).
-					filter(s -> s != null).collect(Collectors.toList());
-		} catch (Exception e) {
-			if (e.getCause() instanceof ScanningException) {
-				throw (ScanningException) e.getCause();
-			} else {
-				throw e;
-			}
-		}
-	}
-	
-	protected INexusDevice<?> getNexusScannable(String scannableName) {
-		try {
-			IScannable<?> scannable = scanDevice.getConnectorService().getScannable(scannableName);
-			if (scannable == null) {
-				throw new IllegalArgumentException("No such scannable: " + scannableName);
-			}
-			if (scannable instanceof INexusDevice<?>) {
-				return (INexusDevice<?>) scannable;
-			}
-			
-			return null;
-		} catch (ScanningException e) {
-			throw new RuntimeException("Error getting scannable with name: " + scannableName, e);
-		}
 	}
 	
 	/**

--- a/org.eclipse.scanning.server/src/org/eclipse/scanning/server/servlet/AcquireRequestHandler.java
+++ b/org.eclipse.scanning.server/src/org/eclipse/scanning/server/servlet/AcquireRequestHandler.java
@@ -11,11 +11,14 @@
  *******************************************************************************/
 package org.eclipse.scanning.server.servlet;
 
+import java.util.Collections;
+
 import org.eclipse.scanning.api.annotation.scan.AnnotationManager;
 import org.eclipse.scanning.api.annotation.scan.PostConfigure;
 import org.eclipse.scanning.api.annotation.scan.PreConfigure;
 import org.eclipse.scanning.api.device.IRunnableDevice;
 import org.eclipse.scanning.api.device.IRunnableDeviceService;
+import org.eclipse.scanning.api.device.IScannableDeviceService;
 import org.eclipse.scanning.api.event.EventException;
 import org.eclipse.scanning.api.event.core.IPublisher;
 import org.eclipse.scanning.api.event.core.IResponseProcess;
@@ -75,17 +78,20 @@ public class AcquireRequestHandler implements IResponseProcess<AcquireRequest> {
 	}
 	
 	private IRunnableDevice<?> createRunnableDevice(AcquireRequest request) throws ScanningException, EventException {
+		// get the services we need
+		final IRunnableDeviceService deviceService = Services.getRunnableDeviceService();
+		final IPointGeneratorService pointGenService = Services.getGeneratorService();
+		
 		final ScanModel scanModel = new ScanModel();
 
 		try {
-			IPointGeneratorService pointGenService = Services.getGeneratorService();
 			IPointGenerator<?> gen = pointGenService.createGenerator(new StaticModel());
 			scanModel.setPositionIterable(gen);
 			
 			scanModel.setFilePath(getOutputFilePath(request));
-			IRunnableDeviceService deviceService = Services.getRunnableDeviceService();
 			IRunnableDevice<?> detector = deviceService.getRunnableDevice(bean.getDetectorName());
 			scanModel.setDetectors(detector);
+			scanModel.setScannables(Collections.emptyList());
 			
 			configureDetector(detector, request.getDetectorModel(), scanModel);
 			return deviceService.createRunnableDevice(scanModel, null);

--- a/org.eclipse.scanning.server/src/org/eclipse/scanning/server/servlet/ScanProcess.java
+++ b/org.eclipse.scanning.server/src/org/eclipse/scanning/server/servlet/ScanProcess.java
@@ -339,6 +339,7 @@ public class ScanProcess implements IConsumerProcess<ScanBean> {
 			scanModel.setFilePath(bean.getFilePath());
 			
 			scanModel.setDetectors(getDetectors(req.getDetectors()));
+			scanModel.setScannables(getScannables(getScannableNames(generator)));
 			scanModel.setMonitors(getScannables(req.getMonitorNames()));
 			scanModel.setScanMetadata(req.getScanMetadata());
 			scanModel.setBean(bean);

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/mocks/MockPositioner.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/event/queues/mocks/MockPositioner.java
@@ -63,21 +63,22 @@ public class MockPositioner implements IPositioner {
 
 	@Override
 	public List<IScannable<?>> getMonitors() throws ScanningException {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
 	@Override
-	public void setMonitors(List<IScannable<?>> monitors)
-			throws ScanningException {
-		// TODO Auto-generated method stub
-
+	public void setMonitors(List<IScannable<?>> monitors) {
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public void setMonitors(IScannable<?>... monitors) throws ScanningException {
-		// TODO Auto-generated method stub
+	public void setMonitors(IScannable<?>... monitors) {
+		throw new UnsupportedOperationException();
+	}
 
+	@Override
+	public void setScannables(List<IScannable<?>> scannables) {
+		throw new UnsupportedOperationException();
 	}
 
 	@Override


### PR DESCRIPTION
…h scan

As jython scannables are no longer cached by ScannableDeviceConnectorService, a new ScannableNexusWrapper is created each time ScannableDeviceConnectorService.getScannable() is called. This meant that we created the nexus objects on wrapper object and wrote to another, resulting in the nexus datasets for jython scannables not being written properly. To fix this we set the scannables in the model. All objects that need to use the scannables in the scan now get them from there, so that we use the same ScannableNexusWrapper objects throughout a scan.

Signed-off-by: Matthew Dickie <matthew.dickie@diamond.ac.uk>