### PR TITLE
Log when LevelRunner.abortException is reset.

### DIFF
--- a/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/LevelRunner.java
+++ b/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/LevelRunner.java
@@ -285,6 +285,9 @@ abstract class LevelRunner<L extends ILevel> {
 	}
 
 	public void reset() {
+		if (abortException != null) {
+			logger.trace("Resetting abortException to null, was ", abortException);
+		}
 		abortException = null;
 	}
 


### PR DESCRIPTION
We had a few instances where exception appeared to be swallowed, so
this log message will help us identify cases where the abortException
is reset before it is re-thrown.