### PR TITLE
Avoid NPE in StepModelComposite

### DIFF
--- a/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/composites/StepModelComposite.java
+++ b/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/composites/StepModelComposite.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.scanning.device.ui.composites;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.richbeans.widgets.scalebox.ScaleBox;
@@ -98,6 +99,7 @@ public class StepModelComposite extends Composite {
 	}
 
 	private void setBounds(Number minimum, Number maximum) {
+		if (Objects.isNull(minimum) || Objects.isNull(maximum)) return;
 		start.setMinimum(minimum.doubleValue());
 		start.setMaximum(maximum.doubleValue());
 		stop.setMinimum(start);


### PR DESCRIPTION
This would happen when scannable.getMinimum() and/or scannable.getMaximum()are null. In this change, we return from setBounds if these are values are null.