### PR TITLE
Remove unneeded commons logging dependency

### DIFF
--- a/org.eclipse.scanning.sequencer/META-INF/MANIFEST.MF
+++ b/org.eclipse.scanning.sequencer/META-INF/MANIFEST.MF
@@ -15,8 +15,7 @@ Require-Bundle: org.eclipse.scanning.api;bundle-version="1.0.0",
  org.eclipse.dawnsci.nexus;bundle-version="1.0.0",
  org.eclipse.january;bundle-version="1.0.0",
  org.eclipse.dawnsci.analysis.api;bundle-version="1.0.0",
- org.apache.commons.jexl;bundle-version="2.1.1",
- org.apache.commons.logging;bundle-version="1.1.1"
+ org.apache.commons.jexl;bundle-version="2.1.1"
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.dawnsci.analysis.dataset.impl,


### PR DESCRIPTION
If this bundle does use commons logging somehow it should be using the
slf4j bridge anyway