### PR TITLE
[DAQ-841] Improvements to usability of ControlTreeViewer

### DIFF
--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/filter/Filter.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/filter/Filter.java
@@ -191,4 +191,9 @@ public class Filter implements IFilter<String> {
 		}
 		return ret;
 	}
+
+	@Override
+	public String toString() {
+		return "Filter [name=" + name + ", excludes=" + excludes + ", includes=" + includes + "]";
+	}
 }

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/filter/FilterService.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/filter/FilterService.java
@@ -18,13 +18,13 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * 
+ *
  * This class is not an OSGi service at the moment
  * because its logic uses only JDK classes therefore
  * we may add the implementation to API using a deeply
  * unfashionable singleton pattern. (This works with
  * Spring rather well however.)
- * 
+ *
  * @author Matthew Gerring
  *
  */
@@ -32,7 +32,7 @@ class FilterService implements IFilterService {
 
 
 	private Map<String, IFilter<?>> filters;
-	
+
  	/**
 	 * Intentionally package private
 	 */
@@ -53,7 +53,9 @@ class FilterService implements IFilterService {
 	@SuppressWarnings("unchecked")
 	@Override
 	public <T> List<T> filter(String filterName, Collection<T> items) {
-		if (!filters.containsKey(filterName)) return new ArrayList<>(items);
+		if (!filters.containsKey(filterName)) {
+			return new ArrayList<>(items);
+		}
 	    return ((IFilter<T>)filters.get(filterName)).filter(items);
 	}
 
@@ -66,5 +68,10 @@ class FilterService implements IFilterService {
 	@Override
 	public void clear() {
 		filters.clear();
+	}
+
+	@Override
+	public String toString() {
+		return "FilterService [filters=" + filters + "]";
 	}
 }

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/scan/ui/AbstractControl.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/scan/ui/AbstractControl.java
@@ -114,7 +114,8 @@ public abstract class AbstractControl implements INamedNode {
 
 	@Override
 	public String toString() {
-		return getClass().getSimpleName()+" [name=" + name + "]";
+		return "AbstractControl [parentName=" + parentName + ", name=" + name + ", displayName=" + displayName
+				+ ", children=" + Arrays.toString(children) + "]";
 	}
 
 	public void addChild(INamedNode child) {

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/scan/ui/ControlTree.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/scan/ui/ControlTree.java
@@ -24,19 +24,19 @@ import org.eclipse.scanning.api.INamedNode;
  * created from spring and serialized to json at different
  * points. Spring calls add(...) on the children and globalize(...)
  * on this class to force the static instance to be a given value.
- * 
+ *
  * There is one static instance but the object is not a singleton
  * because it is created from json files as well. The design is
  * therefore a multiple instance, single static value rather than
  * singleton. This is intentional.
- * 
+ *
  * @author Matthew Gerring
  *
  */
 public class ControlTree extends AbstractControl {
 
 	private static ControlTree instance;
-	
+
 	private Map<String, INamedNode> content;
 	private boolean treeEditable = true;
 
@@ -49,15 +49,15 @@ public class ControlTree extends AbstractControl {
 		setName(name);
 	}
 
-	
+
 	public static ControlTree getInstance() {
 		return instance;
 	}
-	
+
 	public void globalize() { // Called by spring
 		ControlTree.instance = this;
 	}
-	
+
 	/**
 	 * Used to register a control such that a subsequent call
 	 * to 'build' will create a legal tree.
@@ -68,12 +68,12 @@ public class ControlTree extends AbstractControl {
 		if (content.containsKey(object.getName())) throw new RuntimeException("The name '"+object.getName()+"' is already used!");
 		return content.put(object.getName(), object);
 	}
-	
+
 	public INamedNode insert(INamedNode parent, INamedNode child) {
-		
+
 		child.setParentName(parent.getName());
 		((AbstractControl)parent).addChild(child);
-		
+
 		return child;
 	}
 
@@ -84,7 +84,7 @@ public class ControlTree extends AbstractControl {
 
 		content.remove(node.getName());
 	}
-	
+
 	public boolean isEmpty() {
 		return content.isEmpty();
 	}
@@ -94,19 +94,19 @@ public class ControlTree extends AbstractControl {
 
 	/**
 	 * A call to this method tells the factory to validate by reading
-	 * the groups and controls created in spring. 
-	 * 
-	 * It is done this way because at the point where spring creates the 
+	 * the groups and controls created in spring.
+	 *
+	 * It is done this way because at the point where spring creates the
 	 * objects, they might not yet have their names and other details set.
 	 */
 	public boolean build() {
-		
+
 		final List<INamedNode> children = new ArrayList<>();
-		
+
 		for (String name : content.keySet()) {
-			
+
 			INamedNode iNameable = content.get(name);
-			
+
 			if (iNameable instanceof ControlGroup) {
 				children.add(iNameable);
 				iNameable.setParentName(getName());
@@ -126,10 +126,10 @@ public class ControlTree extends AbstractControl {
 				}
 			}
 		}
-	
+
 		return true;
 	}
-	
+
 
 	public Map<String, INamedNode> getContent() {
 		return content;
@@ -183,5 +183,8 @@ public class ControlTree extends AbstractControl {
 		this.treeEditable = treeEditable;
 	}
 
-
+	@Override
+	public String toString() {
+		return "ControlTree [" + super.toString() + ", content=" + content + ", treeEditable=" + treeEditable + "]";
+	}
 }

--- a/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/device/scannable/ControlTreeViewer.java
+++ b/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/device/scannable/ControlTreeViewer.java
@@ -126,6 +126,10 @@ public class ControlTreeViewer {
 
 	private static final Logger logger = LoggerFactory.getLogger(ControlTreeViewer.class);
 
+	public static final String ACTION_ID_ADD_GROUP = "add_group";
+	public static final String ACTION_ID_ADD_CONTROL = "add_control";
+	public static final String ACTION_ID_REMOVE_ELEMENT = "remove_element";
+
 	// Services
 	private final IScannableDeviceService cservice;
 
@@ -265,6 +269,7 @@ public class ControlTreeViewer {
 				edit(nnode, 0);
 			}
 		};
+		addGroup.setId(ACTION_ID_ADD_GROUP);
 
 		// Action to add a new ControlNode
 		final IAction addNode = new Action("Add control", Activator.getImageDescriptor("icons/ui-toolbar--plus.png")) {
@@ -274,6 +279,7 @@ public class ControlTreeViewer {
 			}
 		};
 		addNode.setEnabled(defaultGroupName != null);
+		addNode.setId(ACTION_ID_ADD_CONTROL);
 
 		// Action to remove the currently selected ControlNode or ControlGroup
 		final IAction removeNode = new Action("Remove", Activator.getImageDescriptor("icons/ui-toolbar--minus.png")) {
@@ -283,6 +289,7 @@ public class ControlTreeViewer {
 			}
 		};
 		removeNode.setEnabled(false);
+		removeNode.setId(ACTION_ID_REMOVE_ELEMENT);
 
 		ViewUtil.addGroups("add", mans, addGroup, addNode, removeNode);
 

--- a/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/device/scannable/ControlValueLabelProvider.java
+++ b/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/device/scannable/ControlValueLabelProvider.java
@@ -13,10 +13,8 @@ package org.eclipse.scanning.device.ui.device.scannable;
 
 import java.text.DecimalFormat;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jface.viewers.ColumnLabelProvider;
@@ -38,12 +36,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class ControlValueLabelProvider extends ColumnLabelProvider implements IStyledLabelProvider, IPositionListener {
-	
+
 	private static final Logger logger = LoggerFactory.getLogger(ControlValueLabelProvider.class);
-	
+
 	private IScannableDeviceService cservice;
 	private ControlTreeViewer       viewer;
-	
+
 	public ControlValueLabelProvider(IScannableDeviceService cservice, ControlTreeViewer viewer) {
 		Activator.getStore().setDefault(DevicePreferenceConstants.NUMBER_FORMAT, "##########0.0###");
 		this.cservice = cservice;
@@ -57,7 +55,7 @@ class ControlValueLabelProvider extends ColumnLabelProvider implements IStyledLa
 
 		final String       text       = getText(element);
 		final StyledString styledText = new StyledString(text!=null?text:"");
-		
+
 		INamedNode node = (INamedNode)element;
 		try {
 			if (node instanceof ControlNode) {
@@ -69,34 +67,34 @@ class ControlValueLabelProvider extends ColumnLabelProvider implements IStyledLa
 						styledText.append("    ");
 						styledText.append(scannable.getUnit(), StyledString.DECORATIONS_STYLER);
 					}
-				}				
+				}
 			} else {
-		
+
 				// Intentionally do nothing!
 			}
 		} catch (Exception ne) {
 			String message = ne.getMessage() == null ? "" : ne.getMessage();
 			return styledText.append(message, StyledString.QUALIFIER_STYLER);
 		}
-		
+
 		return styledText;
 	}
-	
+
 	private Map<String, INamedNode>    scannableNodes;
 	private Map<String, IScannable<?>> scannables;
-	
+
 	private void registerListener(IScannable<?> scannable, INamedNode node) {
-		
+
 		if (!(scannable instanceof IPositionListenable)) return;
 		if (scannableNodes==null) scannableNodes = new HashMap<>();
 		if (scannables==null)     scannables     = new ConcurrentHashMap<>();
-		
+
 		String name = scannable.getName();
-		
+
 		if (scannables.containsKey(name)) {
 			((IPositionListenable)scannables.remove(name)).removePositionListener(this);
 		}
-		
+
 		IPositionListenable pl = (IPositionListenable)scannable;
 		pl.addPositionListener(this);
 		scannableNodes.put(name, node);
@@ -110,12 +108,12 @@ class ControlValueLabelProvider extends ColumnLabelProvider implements IStyledLa
 	public void positionChanged(PositionEvent evt) throws ScanningException {
 		updatePosition(evt);
 	}
-	
+
 	@Override
 	public void positionPerformed(PositionEvent evt) throws ScanningException {
 		updatePosition(evt);
 	}
-	
+
 	private void updatePosition(PositionEvent evt) {
 		if (viewer.getViewer().isCellEditorActive()) return;
 		viewer.safeRefresh(scannableNodes.get(evt.getDevice().getName()));
@@ -124,19 +122,20 @@ class ControlValueLabelProvider extends ColumnLabelProvider implements IStyledLa
 	@Override
 	public void dispose() {
 		super.dispose();
-		for (String name : Optional.of(scannables).orElse(Collections.emptyMap()).keySet()) {
-			((IPositionListenable)scannables.remove(name)).removePositionListener(this);
+		if (scannables != null) {
+			for (String name : scannables.keySet()) {
+				((IPositionListenable)scannables.remove(name)).removePositionListener(this);
+			}
 		}
 	}
 
-
 	@Override
 	public String getText(Object element) {
-		
+
 		if(!(element instanceof INamedNode)) return super.getText(element);
-		
+
 		INamedNode node = (INamedNode)element;
-		
+
 		if (cservice==null) return "Server Error";
 		try {
 			if (node instanceof ControlNode) {
@@ -147,12 +146,12 @@ class ControlValueLabelProvider extends ColumnLabelProvider implements IStyledLa
 				}
 
 				Object value = cnode.getValue(viewer.getMode().isDirectlyConnected(), cservice);
-				
+
 				if (value == null) return "!VALUE";
 				if (value instanceof Number) {
 					try {
 						final DecimalFormat format = new DecimalFormat(Activator.getStore().getString(DevicePreferenceConstants.NUMBER_FORMAT));
-						return format.format(value); 
+						return format.format(value);
 					} catch (Exception ne) {
 						logger.warn("Could not format value as a decimal: ", value);
 						return value.toString();
@@ -163,16 +162,16 @@ class ControlValueLabelProvider extends ColumnLabelProvider implements IStyledLa
 				} else if (value instanceof double[]) {
 					return Arrays.toString((double[]) value);
 				}
-				
+
 				return value.toString();
-				
+
 			} else if (node instanceof ControlFileNode) {
 				final ControlFileNode fnode = (ControlFileNode)node;
 				return fnode.getFile();
 			} else if (node instanceof ControlEnumNode) {
 				final ControlEnumNode fnode = (ControlEnumNode)node;
 				return fnode.getValue().toString();
-				
+
 			} else {
 				return ""; // Only controls have values...
 			}
@@ -180,7 +179,7 @@ class ControlValueLabelProvider extends ColumnLabelProvider implements IStyledLa
 			logger.error("Error with value for "+node, ne);
 		    return ne.toString();
 		}
-		
+
 	}
 
 }

--- a/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/device/scannable/NameEditingSupport.java
+++ b/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/device/scannable/NameEditingSupport.java
@@ -26,11 +26,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class NameEditingSupport extends EditingSupport {
-	
+
 	private static final Logger logger = LoggerFactory.getLogger(NameEditingSupport.class);
 	private ControlTreeViewer controlView;
 	private ModelFieldEditorFactory factory;
-	
+
 	public NameEditingSupport(ControlTreeViewer cview) {
 		super(cview.getViewer());
 		this.controlView = cview;
@@ -42,7 +42,7 @@ class NameEditingSupport extends EditingSupport {
 		try {
 			if (element instanceof ControlNode) {
 				return factory.getDeviceEditor(DeviceType.SCANNABLE, (Composite)getViewer().getControl());
-			} 
+			}
 		} catch (Exception ne) {
 			logger.error("Cannot get a proper scannable editor!", ne);
 		}
@@ -71,20 +71,27 @@ class NameEditingSupport extends EditingSupport {
 
 	@Override
 	protected void setValue(Object element, Object value) {
-		
-		String name = (String)value;
-		INamedNode node = (INamedNode)element;
-		
+		if (element == null) {
+			logger.warn("Cannot save entry as row is null");
+			return;
+		}
+		final INamedNode node = (INamedNode)element;
+
+		final String name = (String)value;
+		if (name == null || name.length() == 0) {
+			logger.warn("Cannot save entry as name is null or empty");
+			return;
+		}
+
 		ControlTree tree = controlView.getControlTree();
 		if (tree.contains(name)) {
 			INamedNode other = tree.getNode(name);
 			MessageDialog.openError(getViewer().getControl().getShell(), "Invalid Name '"+name+"'", "The name '"+name+"' is already used for another control.\n\n"
 					+ "The control has a label of '"+other.getDisplayName()+"' and is linked to '"+other.getName()+"' and cannot be redefined.");
 			return;
-			
 		}
 		tree.setName(node, name);
-		
+
 		node.setDisplayName(name);
 		getViewer().refresh();
 	}


### PR DESCRIPTION
The principal changes here are:

- Give each action (Add group, Add control, Remove) an id.
This allows (for example) the dialogue to edit the beamline
configuration to remove actions it does not want to support.

- Check for null pointers/empty strings in ControlValueLabelProvider
& NameEditingSupport 

Other changes:

- Improved toString() functions in AbstractControl & ControlTree

Signed-off-by: Anthony Hull <anthony.hull@diamond.ac.uk>