### PR TITLE
[DAQ-837] Make scanning more robust to errors in per-scan monitors

### DIFF
--- a/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/nexus/NexusScanFileManager.java
+++ b/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/nexus/NexusScanFileManager.java
@@ -264,7 +264,15 @@ public class NexusScanFileManager implements INexusScanFileManager, IPositionLis
 						nexusObjectProvidersForType.add(nexusProvider);
 					}
 				} catch (NexusException e) {
-					throw new ScanningException("Cannot create device: " + e.getMessage(), e);
+					final String deviceName = (nexusDevice instanceof INameable) ? ((INameable) nexusDevice).getName() : "(unknown device)";
+					if (deviceType == ScanRole.MONITOR_PER_SCAN) {
+						// A failure to get a Nexus object for a per-scan monitor is not regarded as fatal,
+						// so just warn the user.
+						logger.warn("Cannot create per-scan monitor {}: {}", deviceName, e.getMessage());
+					} else {
+						// For all other types of device throw an exception
+						throw new ScanningException("Cannot create device: " + deviceName, e);
+					}
 				}
 			}
 


### PR DESCRIPTION
Log a warning instead of throwing an exception

Signed-off-by: Anthony Hull <anthony.hull@diamond.ac.uk>