### PR TITLE
[DAQ-867] If model name is not in filtered scannable list, do not filter

### DIFF
--- a/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/composites/MultiStepComposite.java
+++ b/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/composites/MultiStepComposite.java
@@ -102,15 +102,31 @@ public class MultiStepComposite extends Composite {
 	public void setScannableService(IScannableDeviceService service, MultiStepModel model) throws ScanningException {
 
 		this.scannableConnectorService = service;
-		List<String> names = service.getScannableNames();
-		List<String> items = IFilterService.DEFAULT.filter("org.eclipse.scanning.scannableFilter", names);
-		Collections.sort(items, new SortNatural<>(false));
-		name.setItems(items.toArray(new String[items.size()]));
-		if (model.getName()!=null) {
+		List<String> items = getScannablesList(true);
+		if (model.getName()!= null) {
+			if (!items.contains(model.getName())) {
+				items = getScannablesList(false);
+			}
+			populateComboBox(items);
 			int index = items.indexOf(model.getName());
 			name.select(index);
+		} else {
+			populateComboBox(items);
 		}
 		getParent().layout(new Control[]{this});
+	}
+
+	private List<String> getScannablesList(boolean usingFilter) throws ScanningException {
+		List<String> names = scannableConnectorService.getScannableNames();
+		if (usingFilter) {
+			names = IFilterService.DEFAULT.filter("org.eclipse.scanning.scannableFilter", names);
+		}
+		return names;
+	}
+
+	private void populateComboBox(List<String> items) {
+		Collections.sort(items, new SortNatural<>(false));
+		name.setItems(items.toArray(new String[items.size()]));
 	}
 
 	private void contiguous(StepModel bean, StepModel previous) {


### PR DESCRIPTION
This would happen when the widget is tied to a single scannable, making
the filter inappropriate.

Signed-off-by: Douglas Winter <douglas.winter@diamond.ac.uk>