### PR TITLE
DAQ-903 Reduce logging message to trace

### DIFF
--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/scan/ScanRequest.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/scan/ScanRequest.java
@@ -145,7 +145,7 @@ public class ScanRequest<T> implements Serializable {
 	}
 
 	public void setMonitorNames(Collection<String> monitorNames) {
-		logger.info("setMonitorNames({}) was {} ({})", monitorNames, this.monitorNames, this);
+		logger.trace("setMonitorNames({}) was {} ({})", monitorNames, this.monitorNames, this);
 		this.monitorNames = monitorNames;
 	}
 


### PR DESCRIPTION
This should be a temporary measure to avoid flooding Graylog with these
messages, the real question is why is this method called so often.

Currently in Graylog there are ~68M of these messages
https://graylog.diamond.ac.uk/search?rangetype=relative&fields=message%2Csource&width=1920&relative=432000&q=loggerName%3Aorg.eclipse.scanning.api.event.scan.ScanRequest#fields=message%2Csource
and as there are also large messages they are shortening the history for
everyone.