### PR TITLE
Make service for BeanConfigurator<StepModel>

### DIFF
--- a/org.eclipse.scanning.device.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.scanning.device.ui/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Eclipse-RegisterBuddy: uk.ac.diamond.org.springframework
 Bundle-ManifestVersion: 2
 Bundle-Name: Ui
 Bundle-SymbolicName: org.eclipse.scanning.device.ui;singleton:=true
@@ -24,7 +25,8 @@ Import-Package: org.eclipse.e4.ui.di,
  org.eclipse.e4.ui.model.application.ui.menu,
  org.osgi.framework;version="1.8.0",
  org.osgi.service.event;version="1.3.1",
- org.slf4j;version="1.7.2"
+ org.slf4j;version="1.7.2",
+ org.springframework.beans.factory;version="4.0.6.RELEASE"
 Bundle-Activator: org.eclipse.scanning.device.ui.Activator
 Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/*.xml

--- a/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/IMultiStepConfiguratorService.java
+++ b/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/IMultiStepConfiguratorService.java
@@ -1,0 +1,51 @@
+/*-
+ * Copyright © 2017 Diamond Light Source Ltd.
+ *
+ * This file is part of GDA.
+ *
+ * GDA is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License version 3 as published by the Free
+ * Software Foundation.
+ *
+ * GDA is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with GDA. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.eclipse.scanning.device.ui;
+
+
+import org.eclipse.richbeans.widgets.selector.BeanConfigurator;
+import org.eclipse.scanning.api.points.models.StepModel;
+
+/**
+ * IMultiStepConfiguratorService lets us register instances of {@link MultiStepConfigurator}
+ * configured in Spring to adjust the default {@link StepModel} values of particular scannables.
+ * <p>
+ * In the same style of IFilterService, this is not an OSGi service.
+ */
+public interface IMultiStepConfiguratorService {
+
+	/**
+	 * The default service
+	 */
+	public static final IMultiStepConfiguratorService DEFAULT = new MultiStepConfiguratorService();
+
+	/**
+	 * Call to register a MultiStepConfigurator to this service
+	 * @param multiStepConfigurator
+	 */
+	void register(MultiStepConfigurator multiStepConfigurator);
+
+	/**
+	 * Retrieve configurator registered with a particular scannable name
+	 * @param scannableName
+	 * @return MultiStepConfigurator registered with scannableName, or default implementation
+	 */
+	BeanConfigurator<StepModel> getConfigurator(String scannableName);
+
+}

--- a/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/MultiStepConfigurator.java
+++ b/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/MultiStepConfigurator.java
@@ -1,0 +1,77 @@
+/*-
+ * Copyright © 2017 Diamond Light Source Ltd.
+ *
+ * This file is part of GDA.
+ *
+ * GDA is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License version 3 as published by the Free
+ * Software Foundation.
+ *
+ * GDA is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with GDA. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.eclipse.scanning.device.ui;
+
+import java.util.List;
+
+import org.eclipse.richbeans.widgets.selector.BeanConfigurator;
+import org.eclipse.scanning.api.INameable;
+import org.eclipse.scanning.api.points.models.StepModel;
+import org.eclipse.scanning.device.ui.composites.MultiStepComposite;
+
+/**
+ * This class can be configured in Spring for a given scannable
+ * to change the default {@link StepModel} values created with {@link MultiStepComposite}.
+ * <p>
+ *
+ * The name field must match the name of the scannable as configured in Spring.
+ */
+public class MultiStepConfigurator implements BeanConfigurator<StepModel>, INameable{
+
+	private String name;
+
+	private double start;
+	private double width;
+	private double step;
+
+	public void register() {
+		IMultiStepConfiguratorService.DEFAULT.register(this);
+	}
+
+	public void setStart(double start) {
+		this.start = start;
+	}
+
+	public void setWidth(double width) {
+		this.width = width;
+	}
+
+	public void setStep(double step) {
+		this.step = step;
+	}
+
+	@Override
+	public void configure(StepModel bean, StepModel previous, List<StepModel> context) {
+		bean.setStart(previous!=null ? previous.getStop() : start);
+		bean.setStop(bean.getStart() + width);
+		bean.setStep(step);
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public void setName(String name) {
+		this.name = name;
+
+	}
+
+}

--- a/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/MultiStepConfiguratorService.java
+++ b/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/MultiStepConfiguratorService.java
@@ -1,0 +1,53 @@
+/*-
+ * Copyright © 2017 Diamond Light Source Ltd.
+ *
+ * This file is part of GDA.
+ *
+ * GDA is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License version 3 as published by the Free
+ * Software Foundation.
+ *
+ * GDA is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with GDA. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.eclipse.scanning.device.ui;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.richbeans.widgets.selector.BeanConfigurator;
+import org.eclipse.scanning.api.points.models.StepModel;
+
+public class MultiStepConfiguratorService implements IMultiStepConfiguratorService {
+
+	private Map<String, MultiStepConfigurator> configs;
+
+	protected MultiStepConfiguratorService() {
+		configs = new HashMap<>();
+	}
+
+	@Override
+	public void register(MultiStepConfigurator config) {
+		configs.put(config.getName(), config);
+	}
+
+	@Override
+	public BeanConfigurator<StepModel> getConfigurator(String name) {
+		if (configs.containsKey(name)) {
+			return configs.get(name);
+		} else { // return default implementation
+			return (bean, previous, context) ->  {
+				bean.setStart(previous!=null ? previous.getStop() : 10.0);
+				bean.setStop(bean.getStart() + 10);
+				bean.setStep(1.0);
+			};
+		}
+	}
+
+}

--- a/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/composites/MultiStepComposite.java
+++ b/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/composites/MultiStepComposite.java
@@ -13,7 +13,6 @@ package org.eclipse.scanning.device.ui.composites;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -27,6 +26,7 @@ import org.eclipse.scanning.api.filter.IFilterService;
 import org.eclipse.scanning.api.points.models.MultiStepModel;
 import org.eclipse.scanning.api.points.models.StepModel;
 import org.eclipse.scanning.api.scan.ScanningException;
+import org.eclipse.scanning.device.ui.IMultiStepConfiguratorService;
 import org.eclipse.scanning.device.ui.util.SortNatural;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
@@ -61,6 +61,7 @@ public class MultiStepComposite extends Composite {
 			@Override
 			public void valueChangePerformed(ValueEvent e) {
 				updateUnits(e.getValue());
+				steps.setBeanConfigurator(IMultiStepConfiguratorService.DEFAULT.getConfigurator((String) e.getValue()));
 			}
 		});
 
@@ -70,7 +71,8 @@ public class MultiStepComposite extends Composite {
 		steps.setMinItems(0);
 		steps.setMaxItems(10);
 		steps.setEditorClass(StepModel.class); // Must match generic!
-		steps.setBeanConfigurator((bean, previous, context)->contiguous(bean, previous));
+
+		steps.setBeanConfigurator(IMultiStepConfiguratorService.DEFAULT.getConfigurator(""));
 		steps.setListHeight(80);
 		steps.setRequireSelectionPack(false);
 		steps.setTemplateName("Step");
@@ -127,14 +129,6 @@ public class MultiStepComposite extends Composite {
 	private void populateComboBox(List<String> items) {
 		Collections.sort(items, new SortNatural<>(false));
 		name.setItems(items.toArray(new String[items.size()]));
-	}
-
-	private void contiguous(StepModel bean, StepModel previous) {
-
-		bean.setStart(previous!=null?previous.getStop():10);
-		bean.setStop(bean.getStart()+10);
-		bean.setName(Optional.of(getName().getValue()).orElse("").toString());
-		bean.setStep((bean.getStop()-bean.getStart())/10d);
 	}
 
 	public VerticalListEditor<StepModel> getStepModels() {

--- a/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/composites/StepModelComposite.java
+++ b/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/composites/StepModelComposite.java
@@ -57,6 +57,7 @@ public class StepModelComposite extends Composite {
 		step.setUnit("eV");
 		step.setMinimum(Integer.getInteger("org.eclipse.scanning.device.ui.composites.stepMin", -10000).doubleValue());
 		step.setMaximum(Integer.getInteger("org.eclipse.scanning.device.ui.composites.stepMax", 10000).doubleValue());
+		step.setDecimalPlaces(4);
 
 		label = new Label(this, SWT.HORIZONTAL|SWT.SEPARATOR);
 		label.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 2, 1));

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/ui/composites/MultiStepCompositeTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/ui/composites/MultiStepCompositeTest.java
@@ -84,7 +84,7 @@ public class MultiStepCompositeTest extends ShellTest{
 			assertEquals(1, bot.table(0).rowCount());
 			assertEquals("10000.00 eV", bot.styledText(0).getText());
 			assertEquals("20000.00 eV", bot.styledText(1).getText());
-			assertEquals("1000.00 eV",  bot.styledText(2).getText());
+			assertEquals("1000.0000 eV",  bot.styledText(2).getText());
 			assertEquals("0.000 s",  bot.styledText(3).getText());
 		} finally {
 			model.clear();
@@ -100,7 +100,7 @@ public class MultiStepCompositeTest extends ShellTest{
 			assertEquals(1, bot.table(0).rowCount());
 			assertEquals("10.10 eV", bot.styledText(0).getText());
 			assertEquals("20.20 eV", bot.styledText(1).getText());
-			assertEquals("1.40 eV",  bot.styledText(2).getText());
+			assertEquals("1.4000 eV",  bot.styledText(2).getText());
 			assertEquals("1.000 s",  bot.styledText(3).getText());
 		} finally {
 			model.clear();
@@ -120,7 +120,7 @@ public class MultiStepCompositeTest extends ShellTest{
 			assertEquals(1, bot.table(0).rowCount());
 			assertEquals("20.20 eV", bot.styledText(0).getText());
 			assertEquals("10.10 eV", bot.styledText(1).getText());
-			assertEquals("-1.40 eV", bot.styledText(2).getText());
+			assertEquals("-1.4000 eV", bot.styledText(2).getText());
 			assertEquals("1.000 s",  bot.styledText(3).getText());
 
 			Color red = new Color(bot.getDisplay(), 255, 0, 0, 255);


### PR DESCRIPTION
This change allows us to configure MultiStepConfigurator (BeanConfigurator<StepModel>) for a given scannable to adjust default StepModel parameters created with MultiStepComposite.

Also in this pull request, I increased the number of allowed decimal places for 'Step' in StepModelComposite.