### PR TITLE
Improve javadoc for DeviceAnnotations

### DIFF
--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/DeviceAnnotations.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/DeviceAnnotations.java
@@ -17,6 +17,61 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+/**
+ * Used to annotate methods as participating in a scan.
+ * <p>
+ * It is possible using annotations to have more than one method annotated
+ * which means a super class can declare its implementation as final, requiring a
+ * subclass to define another annotation.
+ * <p>
+ * Services such as IRunnableDeviceService, IPointsGenerator etc may be declared
+ * in the method which we annotate. These will be passed in if am implementation
+ * of them can be found or null with the method still called (which then will often
+ * cause an NPE causing the scan to abort normally).
+ * <p>
+ * If the information about the scan is required (size, shape etc.) then the class
+ * ScanInformation may be received by the annotated method. If the current position is
+ * needed then the IPosition for it should be declared at the pointStart.
+ * <p>
+ * Examples:<p>
+ * <code><pre>
+ * public class Fred implements IScannable {
+ *     &#64;ScanStart
+ *     public final void prepareVoltages() throws Exception {
+ *        ...
+ *     }
+ *     &#64;ScanEnd
+ *     public void dispose() {
+ *        ...
+ *     }
+ *     ...
+ * }
+ * public class Bill extends Fred {
+ *     &#64;ScanStart
+ *     public void moveToNonObstructingLocation(IRunnableDeviceService<?> rservice) throws Exception {
+ *        ...
+ *     }
+ *     &#64;PointStart
+ *     public void checkNextMoveLegal(IPosition pos) throws Exception {
+ *        ...
+ *     }
+ *     &#64;PointStart
+ *     public void notifyPosition(IPosition pos) throws Exception {
+ *        ...
+ *     }
+ *     &#64;PointEnd
+ *     public void deleteLocation() {
+ *        ...
+ *     }
+ *     &#64;Override
+ *     &#64;ScanEnd
+ *     public void dispose() {
+ *        super.dispose();
+ *        ....
+ *     }
+ *}
+ * </pre></code>
+ */
 public class DeviceAnnotations {
 
 	private static final Set<Class<? extends Annotation>> annotations;

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/FileDeclared.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/FileDeclared.java
@@ -17,66 +17,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
+ * Used to annotate methods as participating in a scan.
+ *
  * Used to annotate methods which wish to be notified when a file
  * to which we will write, is declared for use in a scan.
+ *
  * FileDeclared is invoked after ScanStart and before anything else.
  *
- * <p>
- * It is possible using annotations to have more than one method annotated
- * which means a super class can declare its implementation as final, requiring a
- * subclass to define another annotation.
- * <p>
- * Services such as IRunnableDeviceService, IPointsGenerator etc may be declared
- * in the method which we annotate. These will be passed in if am implementation
- * of them can be found or null with the method still called (which then will often
- * cause an NPE causing the scan to abort normally).
- * <p>
- * If the information about the scan is required (size, shape etc.) then the class
- * ScanInformation may be received by the annotated method. If the current position is
- * needed then the IPosition for it should be declared at the pointStart.
- * <p>
- * Examples:<p>
- * <code><pre>
- * public class Fred implements IScannable {
- *     &#64;ScanStart
- *     public final void prepareVoltages() throws Exception {
- *        ...
- *     }
- *     &#64;ScanEnd
- *     public void dispose() {
- *        ...
- *     }
- *     ...
- * }
- * public class Bill extends Fred {
- *     &#64;ScanStart
- *     public void moveToNonObstructingLocation(IRunnableDeviceService<?> rservice) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void checkNextMoveLegal(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void notifyPosition(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointEnd
- *     public void deleteLocation() {
- *        ...
- *     }
- *     &#64;Override
- *     &#64;ScanEnd
- *     public void dispose() {
- *        super.dispose();
- *        ....
- *     }
- *}
- * </pre></code>
- *
- * <p>
  * @author Matthew Gerring
- *
+ * @see DeviceAnnotations
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/LevelEnd.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/LevelEnd.java
@@ -17,63 +17,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotation methods as participating at a location in a scan.
- * <p>
- * It is possible using annotations to have more than one method annotated
- * which means a super class can declare its implementation as final, requiring a
- * subclass to define another annotation.
- * <p>
- * Services such as IRunnableDeviceService, IPointsGenerator etc may be declared
- * in the method which we annotate. These will be passed in if am implementation
- * of them can be found or null with the method still called (which then will often
- * cause an NPE causing the scan to abort normally).
- * <p>
- * If the information about the scan is required (size, shape etc.) then the class
- * ScanInformation may be received by the annotated method. If the current position is
- * needed then the IPosition for it should be declared at the pointStart.
- * <p>
- * Examples:<p>
- * <code><pre>
- * public class Fred implements IScannable {
- *     &#64;ScanStart
- *     public final void prepareVoltages() throws Exception {
- *        ...
- *     }
- *     &#64;ScanEnd
- *     public void dispose() {
- *        ...
- *     }
- *     ...
- * }
- * public class Bill extends Fred {
- *     &#64;ScanStart
- *     public void moveToNonObstructingLocation(IRunnableDeviceService<?> rservice) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void checkNextMoveLegal(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void notifyPosition(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointEnd
- *     public void deleteLocation() {
- *        ...
- *     }
- *     &#64;Override
- *     &#64;ScanEnd
- *     public void dispose() {
- *        super.dispose();
- *        ....
- *     }
- *}
- * </pre></code>
+ * Used to annotate methods as participating in a scan.
  *
- * <p>
+ * Called at each level end.
+ *
  * @author Matthew Gerring
- *
+ * @see DeviceAnnotations
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/LevelStart.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/LevelStart.java
@@ -17,63 +17,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotation methods as participating at a location in a scan.
- * <p>
- * It is possible using annotations to have more than one method annotated
- * which means a super class can declare its implementation as final, requiring a
- * subclass to define another annotation.
- * <p>
- * Services such as IRunnableDeviceService, IPointsGenerator etc may be declared
- * in the method which we annotate. These will be passed in if am implementation
- * of them can be found or null with the method still called (which then will often
- * cause an NPE causing the scan to abort normally).
- * <p>
- * If the information about the scan is required (size, shape etc.) then the class
- * ScanInformation may be received by the annotated method. If the current position is
- * needed then the IPosition for it should be declared at the pointStart.
- * <p>
- * Examples:<p>
- * <code><pre>
- * public class Fred implements IScannable {
- *     &#64;ScanStart
- *     public final void prepareVoltages() throws Exception {
- *        ...
- *     }
- *     &#64;ScanEnd
- *     public void dispose() {
- *        ...
- *     }
- *     ...
- * }
- * public class Bill extends Fred {
- *     &#64;ScanStart
- *     public void moveToNonObstructingLocation(IRunnableDeviceService<?> rservice) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void checkNextMoveLegal(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void notifyPosition(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointEnd
- *     public void deleteLocation() {
- *        ...
- *     }
- *     &#64;Override
- *     &#64;ScanEnd
- *     public void dispose() {
- *        super.dispose();
- *        ....
- *     }
- *}
- * </pre></code>
+ * Used to annotate methods as participating in a scan.
  *
- * <p>
+ * Called at each level start.
+ *
  * @author Matthew Gerring
- *
+ * @see DeviceAnnotations
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/PointEnd.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/PointEnd.java
@@ -17,63 +17,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotation methods as participating at a location in a scan.
- * <p>
- * It is possible using annotations to have more than one method annotated
- * which means a super class can declare its implementation as final, requiring a
- * subclass to define another annotation.
- * <p>
- * Services such as IRunnableDeviceService, IPointsGenerator etc may be declared
- * in the method which we annotate. These will be passed in if am implementation
- * of them can be found or null with the method still called (which then will often
- * cause an NPE causing the scan to abort normally).
- * <p>
- * If the information about the scan is required (size, shape etc.) then the class
- * ScanInformation may be received by the annotated method. If the current position is
- * needed then the IPosition for it should be declared at the pointStart.
- * <p>
- * Examples:<p>
- * <code><pre>
- * public class Fred implements IScannable {
- *     &#64;ScanStart
- *     public final void prepareVoltages() throws Exception {
- *        ...
- *     }
- *     &#64;ScanEnd
- *     public void dispose() {
- *        ...
- *     }
- *     ...
- * }
- * public class Bill extends Fred {
- *     &#64;ScanStart
- *     public void moveToNonObstructingLocation(IRunnableDeviceService<?> rservice) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void checkNextMoveLegal(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void notifyPosition(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointEnd
- *     public void deleteLocation() {
- *        ...
- *     }
- *     &#64;Override
- *     &#64;ScanEnd
- *     public void dispose() {
- *        super.dispose();
- *        ....
- *     }
- *}
- * </pre></code>
+ * Used to annotate methods as participating in a scan.
  *
- * <p>
+ * Called at each point end.
+ *
  * @author Matthew Gerring
- *
+ * @see DeviceAnnotations
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/PointStart.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/PointStart.java
@@ -17,63 +17,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotation methods as participating at a location in a scan.
- * <p>
- * It is possible using annotations to have more than one method annotated
- * which means a super class can declare its implementation as final, requiring a
- * subclass to define another annotation.
- * <p>
- * Services such as IRunnableDeviceService, IPointsGenerator etc may be declared
- * in the method which we annotate. These will be passed in if am implementation
- * of them can be found or null with the method still called (which then will often
- * cause an NPE causing the scan to abort normally).
- * <p>
- * If the information about the scan is required (size, shape etc.) then the class
- * ScanInformation may be received by the annotated method. If the current position is
- * needed then the IPosition for it should be declared at the pointStart.
- * <p>
- * Examples:<p>
- * <code><pre>
- * public class Fred implements IScannable {
- *     &#64;ScanStart
- *     public final void prepareVoltages() throws Exception {
- *        ...
- *     }
- *     &#64;ScanEnd
- *     public void dispose() {
- *        ...
- *     }
- *     ...
- * }
- * public class Bill extends Fred {
- *     &#64;ScanStart
- *     public void moveToNonObstructingLocation(IRunnableDeviceService<?> rservice) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void checkNextMoveLegal(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void notifyPosition(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointEnd
- *     public void deleteLocation() {
- *        ...
- *     }
- *     &#64;Override
- *     &#64;ScanEnd
- *     public void dispose() {
- *        super.dispose();
- *        ....
- *     }
- *}
- * </pre></code>
+ * Used to annotate methods as participating in a scan.
  *
- * <p>
+ * Called at each point start.
+ *
  * @author Matthew Gerring
- *
+ * @see DeviceAnnotations
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/PostConfigure.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/PostConfigure.java
@@ -17,63 +17,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotation methods as participating at a location in a scan.
- * <p>
- * It is possible using annotations to have more than one method annotated
- * which means a super class can declare its implementation as final, requiring a
- * subclass to define another annotation.
- * <p>
- * Services such as IRunnableDeviceService, IPointsGenerator etc may be declared
- * in the method which we annotate. These will be passed in if am implementation
- * of them can be found or null with the method still called (which then will often
- * cause an NPE causing the scan to abort normally).
- * <p>
- * If the information about the scan is required (size, shape etc.) then the class
- * ScanInformation may be received by the annotated method. If the current position is
- * needed then the IPosition for it should be declared at the pointStart.
- * <p>
- * Examples:<p>
- * <code><pre>
- * public class Fred implements IScannable {
- *     &#64;ScanStart
- *     public final void prepareVoltages() throws Exception {
- *        ...
- *     }
- *     &#64;ScanEnd
- *     public void dispose() {
- *        ...
- *     }
- *     ...
- * }
- * public class Bill extends Fred {
- *     &#64;ScanStart
- *     public void moveToNonObstructingLocation(IRunnableDeviceService<?> rservice) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void checkNextMoveLegal(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void notifyPosition(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointEnd
- *     public void deleteLocation() {
- *        ...
- *     }
- *     &#64;Override
- *     &#64;ScanEnd
- *     public void dispose() {
- *        super.dispose();
- *        ....
- *     }
- *}
- * </pre></code>
+ * Used to annotate methods as participating in a scan.
  *
- * <p>
+ * Called before configure.
+ *
  * @author Matthew Gerring
- *
+ * @see DeviceAnnotations
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/PreConfigure.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/PreConfigure.java
@@ -17,63 +17,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotation methods as participating at a location in a scan.
- * <p>
- * It is possible using annotations to have more than one method annotated
- * which means a super class can declare its implementation as final, requiring a
- * subclass to define another annotation.
- * <p>
- * Services such as IRunnableDeviceService, IPointsGenerator etc may be declared
- * in the method which we annotate. These will be passed in if am implementation
- * of them can be found or null with the method still called (which then will often
- * cause an NPE causing the scan to abort normally).
- * <p>
- * If the information about the scan is required (size, shape etc.) then the class
- * ScanInformation may be received by the annotated method. If the current position is
- * needed then the IPosition for it should be declared at the pointStart.
- * <p>
- * Examples:<p>
- * <code><pre>
- * public class Fred implements IScannable {
- *     &#64;ScanStart
- *     public final void prepareVoltages() throws Exception {
- *        ...
- *     }
- *     &#64;ScanEnd
- *     public void dispose() {
- *        ...
- *     }
- *     ...
- * }
- * public class Bill extends Fred {
- *     &#64;ScanStart
- *     public void moveToNonObstructingLocation(IRunnableDeviceService<?> rservice) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void checkNextMoveLegal(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void notifyPosition(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointEnd
- *     public void deleteLocation() {
- *        ...
- *     }
- *     &#64;Override
- *     &#64;ScanEnd
- *     public void dispose() {
- *        super.dispose();
- *        ....
- *     }
- *}
- * </pre></code>
+ * Used to annotate methods as participating in a scan.
  *
- * <p>
+ * Called after configure.
+ *
  * @author Matthew Gerring
- *
+ * @see DeviceAnnotations
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/ScanAbort.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/ScanAbort.java
@@ -17,63 +17,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotation methods as participating at a location in a scan.
- * <p>
- * It is possible using annotations to have more than one method annotated
- * which means a super class can declare its implementation as final, requiring a
- * subclass to define another annotation.
- * <p>
- * Services such as IRunnableDeviceService, IPointsGenerator etc may be declared
- * in the method which we annotate. These will be passed in if am implementation
- * of them can be found or null with the method still called (which then will often
- * cause an NPE causing the scan to abort normally).
- * <p>
- * If the information about the scan is required (size, shape etc.) then the class
- * ScanInformation may be received by the annotated method. If the current position is
- * needed then the IPosition for it should be declared at the pointStart.
- * <p>
- * Examples:<p>
- * <code><pre>
- * public class Fred implements IScannable {
- *     &#64;ScanStart
- *     public final void prepareVoltages() throws Exception {
- *        ...
- *     }
- *     &#64;ScanEnd
- *     public void dispose() {
- *        ...
- *     }
- *     ...
- * }
- * public class Bill extends Fred {
- *     &#64;ScanStart
- *     public void moveToNonObstructingLocation(IRunnableDeviceService<?> rservice) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void checkNextMoveLegal(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void notifyPosition(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointEnd
- *     public void deleteLocation() {
- *        ...
- *     }
- *     &#64;Override
- *     &#64;ScanEnd
- *     public void dispose() {
- *        super.dispose();
- *        ....
- *     }
- *}
- * </pre></code>
+ * Used to annotate methods as participating in a scan.
  *
- * <p>
+ * Called when the scan is aborted.
+ *
  * @author Matthew Gerring
- *
+ * @see DeviceAnnotations
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/ScanEnd.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/ScanEnd.java
@@ -17,67 +17,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotate methods as participating at a location in a scan.
- * ScanEnd is called after the files are closed for writing and the scan
- * has finished with success. It is called before ScanFinally but will not
- * be called if no success occurred.
+ * Used to annotate methods as participating in a scan.
  *
- * <p>
- * It is possible using annotations to have more than one method annotated
- * which means a super class can declare its implementation as final, requiring a
- * subclass to define another annotation.
- * <p>
- * Services such as IRunnableDeviceService, IPointsGenerator etc may be declared
- * in the method which we annotate. These will be passed in if am implementation
- * of them can be found or null with the method still called (which then will often
- * cause an NPE causing the scan to abort normally).
- * <p>
- * If the information about the scan is required (size, shape etc.) then the class
- * ScanInformation may be received by the annotated method. If the current position is
- * needed then the IPosition for it should be declared at the pointStart.
- * <p>
- * Examples:<p>
- * <code><pre>
- * public class Fred implements IScannnable {
- *     &#64;ScanStart
- *     public final void prepareVoltages() throws Exception {
- *        ...
- *     }
- *     &#64;ScanEnd
- *     public void dispose() {
- *        ...
- *     }
- *     ...
- * }
- * public class Bill extends Fred {
- *     &#64;ScanStart
- *     public void moveToNonObstructingLocation(IRunnableDeviceService<?> rservice) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void checkNextMoveLegal(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void notifyPosition(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointEnd
- *     public void deleteLocation() {
- *        ...
- *     }
- *     &#64;Override
- *     &#64;ScanEnd
- *     public void dispose() {
- *        super.dispose();
- *        ....
- *     }
- *}
- * </pre></code>
+ * Called after the files are closed for writing and the scan has finished with
+ * success.
  *
- * <p>
+ * It is called before ScanFinally but will not be called if an error occurred.
+ *
  * @author Matthew Gerring
- *
+ * @see DeviceAnnotations
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/ScanFault.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/ScanFault.java
@@ -17,63 +17,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotation methods as participating at a location in a scan.
- * <p>
- * It is possible using annotations to have more than one method annotated
- * which means a super class can declare its implementation as final, requiring a
- * subclass to define another annotation.
- * <p>
- * Services such as IRunnableDeviceService, IPointsGenerator etc may be declared
- * in the method which we annotate. These will be passed in if am implementation
- * of them can be found or null with the method still called (which then will often
- * cause an NPE causing the scan to abort normally).
- * <p>
- * If the information about the scan is required (size, shape etc.) then the class
- * ScanInformation may be received by the annotated method. If the current position is
- * needed then the IPosition for it should be declared at the pointStart.
- * <p>
- * Examples:<p>
- * <code><pre>
- * public class Fred implements IScannable {
- *     &#64;ScanStart
- *     public final void prepareVoltages() throws Exception {
- *        ...
- *     }
- *     &#64;ScanEnd
- *     public void dispose() {
- *        ...
- *     }
- *     ...
- * }
- * public class Bill extends Fred {
- *     &#64;ScanStart
- *     public void moveToNonObstructingLocation(IRunnableDeviceService<?> rservice) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void checkNextMoveLegal(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void notifyPosition(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointEnd
- *     public void deleteLocation() {
- *        ...
- *     }
- *     &#64;Override
- *     &#64;ScanEnd
- *     public void dispose() {
- *        super.dispose();
- *        ....
- *     }
- *}
- * </pre></code>
+ * Used to annotate methods as participating in a scan.
  *
- * <p>
+ * Called when a running scan has a fault.
+ *
  * @author Matthew Gerring
- *
+ * @see DeviceAnnotations
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/ScanFinally.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/ScanFinally.java
@@ -17,67 +17,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotate methods as participating at a location in a scan.
- * ScanFinally is called after ScanEnd but ScanEnd is not called if there was an error.
+ * Used to annotate methods as participating in a scan.
  *
- * <p>
- * It is possible using annotations to have more than one method annotated
- * which means a super class can declare its implementation as final, requiring a
- * subclass to define another annotation.
- * <p>
- * Services such as IRunnableDeviceService, IPointsGenerator etc may be declared
- * in the method which we annotate. These will be passed in if am implementation
- * of them can be found or null with the method still called (which then will often
- * cause an NPE causing the scan to abort normally).
- * <p>
- * If the information about the scan is required (size, shape etc.) then the class
- * ScanInformation may be received by the annotated method. If the current position is
- * needed then the IPosition for it should be declared at the pointStart.
- * <p>
- * Examples:<p>
- * <code><pre>
- * public class Fred implements IScannable {
- *     &#64;ScanStart
- *     public final void prepareVoltages() throws Exception {
- *        ...
- *     }
- *     &#64;ScanEnd
- *     public void dispose() {
- *        ...
- *     }
- *     ...
- * }
- * public class Bill extends Fred {
- *     &#64;ScanStart
- *     public void moveToNonObstructingLocation(IRunnableDeviceService<?> rservice) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void checkNextMoveLegal(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void notifyPosition(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointEnd
- *     public void deleteLocation() {
- *        ...
- *     }
- *     &#64;Override
- *     &#64;ScanEnd
- *     public void dispose() {
- *        super.dispose();
- *        ....
- *     }
- *}
- * </pre></code>
+ * Called after all other annotations once a scan has started.
  *
- * ScanFinally is always run, even if there was an error.
+ * Will be called even if ScanEnd isn't called.
  *
- * <p>
  * @author Matthew Gerring
- *
+ * @see DeviceAnnotations
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/ScanPause.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/ScanPause.java
@@ -17,63 +17,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotation methods as participating at a location in a scan.
- * <p>
- * It is possible using annotations to have more than one method annotated
- * which means a super class can declare its implementation as final, requiring a
- * subclass to define another annotation.
- * <p>
- * Services such as IRunnableDeviceService, IPointsGenerator etc may be declared
- * in the method which we annotate. These will be passed in if am implementation
- * of them can be found or null with the method still called (which then will often
- * cause an NPE causing the scan to abort normally).
- * <p>
- * If the information about the scan is required (size, shape etc.) then the class
- * ScanInformation may be received by the annotated method. If the current position is
- * needed then the IPosition for it should be declared at the pointStart.
- * <p>
- * Examples:<p>
- * <code><pre>
- * public class Fred implements IScannable {
- *     &#64;ScanStart
- *     public final void prepareVoltages() throws Exception {
- *        ...
- *     }
- *     &#64;ScanEnd
- *     public void dispose() {
- *        ...
- *     }
- *     ...
- * }
- * public class Bill extends Fred {
- *     &#64;ScanStart
- *     public void moveToNonObstructingLocation(IRunnableDeviceService<?> rservice) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void checkNextMoveLegal(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void notifyPosition(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointEnd
- *     public void deleteLocation() {
- *        ...
- *     }
- *     &#64;Override
- *     &#64;ScanEnd
- *     public void dispose() {
- *        super.dispose();
- *        ....
- *     }
- *}
- * </pre></code>
+ * Used to annotate methods as participating in a scan.
  *
- * <p>
+ * Called whenever a scan is paused.
+ *
  * @author Matthew Gerring
- *
+ * @see DeviceAnnotations
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/ScanResume.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/ScanResume.java
@@ -17,63 +17,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotation methods as participating at a location in a scan.
- * <p>
- * It is possible using annotations to have more than one method annotated
- * which means a super class can declare its implementation as final, requiring a
- * subclass to define another annotation.
- * <p>
- * Services such as IRunnableDeviceService, IPointsGenerator etc may be declared
- * in the method which we annotate. These will be passed in if am implementation
- * of them can be found or null with the method still called (which then will often
- * cause an NPE causing the scan to abort normally).
- * <p>
- * If the information about the scan is required (size, shape etc.) then the class
- * ScanInformation may be received by the annotated method. If the current position is
- * needed then the IPosition for it should be declared at the pointStart.
- * <p>
- * Examples:<p>
- * <code><pre>
- * public class Fred implements IScannable {
- *     &#64;ScanStart
- *     public final void prepareVoltages() throws Exception {
- *        ...
- *     }
- *     &#64;ScanEnd
- *     public void dispose() {
- *        ...
- *     }
- *     ...
- * }
- * public class Bill extends Fred {
- *     &#64;ScanStart
- *     public void moveToNonObstructingLocation(IRunnableDeviceService<?> rservice) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void checkNextMoveLegal(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void notifyPosition(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointEnd
- *     public void deleteLocation() {
- *        ...
- *     }
- *     &#64;Override
- *     &#64;ScanEnd
- *     public void dispose() {
- *        super.dispose();
- *        ....
- *     }
- *}
- * </pre></code>
+ * Used to annotate methods as participating in a scan.
  *
- * <p>
+ * Called whenever a scan is resumed.
+ *
  * @author Matthew Gerring
- *
+ * @see DeviceAnnotations
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/ScanStart.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/ScanStart.java
@@ -17,63 +17,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotation methods as participating at a location in a scan.
- * <p>
- * It is possible using annotations to have more than one method annotated
- * which means a super class can declare its implementation as final, requiring a
- * subclass to define another annotation.
- * <p>
- * Services such as IRunnableDeviceService, IPointsGenerator etc may be declared
- * in the method which we annotate. These will be passed in if am implementation
- * of them can be found or null with the method still called (which then will often
- * cause an NPE causing the scan to abort normally).
- * <p>
- * If the information about the scan is required (size, shape etc.) then the class
- * ScanInformation may be received by the annotated method. If the current position is
- * needed then the IPosition for it should be declared at the pointStart.
- * <p>
- * Examples:<p>
- * <code><pre>
- * public class Fred implements IScannable {
- *     &#64;ScanStart
- *     public final void prepareVoltages() throws Exception {
- *        ...
- *     }
- *     &#64;ScanEnd
- *     public void dispose() {
- *        ...
- *     }
- *     ...
- * }
- * public class Bill extends Fred {
- *     &#64;ScanStart
- *     public void moveToNonObstructingLocation(IRunnableDeviceService<?> rservice) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void checkNextMoveLegal(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void notifyPosition(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointEnd
- *     public void deleteLocation() {
- *        ...
- *     }
- *     &#64;Override
- *     &#64;ScanEnd
- *     public void dispose() {
- *        super.dispose();
- *        ....
- *     }
- *}
- * </pre></code>
+ * Used to annotate methods as participating in a scan.
  *
- * <p>
+ * Called whenver a scan started, after a successful configuration.
+ *
  * @author Matthew Gerring
- *
+ * @see DeviceAnnotations
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/WriteComplete.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/annotation/scan/WriteComplete.java
@@ -17,66 +17,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotation methods as participating at a location in a scan.
+ * Used to annotate methods as participating in a scan.
+ *
  * This location is for a position after the write(...) method of a detector
  * has finished.
  *
- * <p>
- * It is possible using annotations to have more than one method annotated
- * which means a super class can declare its implementation as final, requiring a
- * subclass to define another annotation.
- * <p>
- * Services such as IRunnableDeviceService, IPointsGenerator etc may be declared
- * in the method which we annotate. These will be passed in if am implementation
- * of them can be found or null with the method still called (which then will often
- * cause an NPE causing the scan to abort normally).
- * <p>
- * If the information about the scan is required (size, shape etc.) then the class
- * ScanInformation may be received by the annotated method. If the current position is
- * needed then the IPosition for it should be declared at the pointStart.
- * <p>
- * Examples:<p>
- * <code><pre>
- * public class Fred implements IScannable {
- *     &#64;ScanStart
- *     public final void prepareVoltages() throws Exception {
- *        ...
- *     }
- *     &#64;ScanEnd
- *     public void dispose() {
- *        ...
- *     }
- *     ...
- * }
- * public class Bill extends Fred {
- *     &#64;ScanStart
- *     public void moveToNonObstructingLocation(IRunnableDeviceService<?> rservice) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void checkNextMoveLegal(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointStart
- *     public void notifyPosition(IPosition pos) throws Exception {
- *        ...
- *     }
- *     &#64;PointEnd
- *     public void deleteLocation() {
- *        ...
- *     }
- *     &#64;Override
- *     &#64;ScanEnd
- *     public void dispose() {
- *        super.dispose();
- *        ....
- *     }
- *}
- * </pre></code>
- *
- * <p>
  * @author Matthew Gerring
- *
+ * @see DeviceAnnotations
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
Remove the duplicated, undifferentiated javadoc in each annotation, and
replace it with indiviual javadoc for each annotation, plus a link to
the DeviceAnnotation class javadoc which contains a the javadoc which
was duplicated elsewhere.

This should make it easier to use these annotations and keep the javadoc
up to date.