### PR TITLE
ExpressionWatchdog: let job be paused from start

### DIFF
--- a/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/watchdog/ExpressionWatchdog.java
+++ b/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/watchdog/ExpressionWatchdog.java
@@ -145,10 +145,7 @@ public class ExpressionWatchdog extends AbstractWatchdog implements IPositionLis
 		    }
 
 		    // Check it
-		    boolean ok = checkExpression(false);
-		    if (!ok) {
-			throw new ScanningException(model.getMessage()+". The expression '"+model.getExpression()+"' is false and a scan may not be run!");
-		    }
+		    checkExpression(true);
 
 		    // Listen to it
 		    for (IScannable<?> scannable : scannables) {

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/WatchdogCombinedTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/WatchdogCombinedTest.java
@@ -178,6 +178,21 @@ public class WatchdogCombinedTest extends AbstractWatchdogTest {
 		}
 	}
 
+	@Test
+	public void startWhilstTopupInProgress() throws Exception {
+		// make edog evaluate to false
+		connector.getScannable("beamcurrent").setPosition(0.5);
+
+		IDeviceController controller = createTestScanner(null);
+		IRunnableEventDevice<?> scanner = (IRunnableEventDevice<?>)controller.getDevice();
+
+		scanner.start(null);
+		scanner.latch(500, TimeUnit.MILLISECONDS);
+
+		// the device should be now be paused
+		assertEquals(DeviceState.PAUSED, scanner.getDeviceState());
+	}
+
 
 	@Test
 	public void disabledTopup() throws Exception {

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/WatchdogCombinedTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/WatchdogCombinedTest.java
@@ -179,7 +179,7 @@ public class WatchdogCombinedTest extends AbstractWatchdogTest {
 	}
 
 	@Test
-	public void startWhilstTopupInProgress() throws Exception {
+	public void startWhenExpressionWatchdogEvaluatesFalse() throws Exception {
 		// make edog evaluate to false
 		connector.getScannable("beamcurrent").setPosition(0.5);
 

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/WatchdogShutterTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/WatchdogShutterTest.java
@@ -162,7 +162,7 @@ public class WatchdogShutterTest extends AbstractWatchdogTest {
 
 	}
 
-	@Test(expected=ScanningException.class)
+	@Test
 	public void scanDuringShutterClosed() throws Exception {
 
 		// Stop topup, we want to control it programmatically.
@@ -182,7 +182,10 @@ public class WatchdogShutterTest extends AbstractWatchdogTest {
 		});
 
 		scanner.start(null);
-		scanner.latch(250, TimeUnit.MILLISECONDS); // Wait for an exception
+		scanner.latch(250, TimeUnit.MILLISECONDS);
+
+		// By now, queue should be paused.
+		assertEquals(DeviceState.PAUSED, scanner.getDeviceState());
 	}
 
 	@Test


### PR DESCRIPTION
Before this change, a scan which was started while ExpressionWatchdog
evaluated to false would throw ScanningException and fail. Now, the job
would simply be paused until the expression evaluates to true.

Signed-off-by: Douglas Winter <douglas.winter@diamond.ac.uk>