### PR TITLE
Update scanpointgenerator to Pull Request #48 (commit 380fa87e)

### DIFF
--- a/org.eclipse.scanning.points/scripts/scanpointgenerator/core/compoundgenerator.py
+++ b/org.eclipse.scanning.points/scripts/scanpointgenerator/core/compoundgenerator.py
@@ -23,7 +23,7 @@ from scanpointgenerator.core.excluder import Excluder
 from scanpointgenerator.excluders.roiexcluder import ROIExcluder
 from scanpointgenerator.core.mutator import Mutator
 from scanpointgenerator.rois import RectangularROI
-from scanpointgenerator.generators import LineGenerator
+from scanpointgenerator.generators import LineGenerator, NullPointGenerator
 
 
 class CompoundGenerator(object):
@@ -141,39 +141,27 @@ class CompoundGenerator(object):
             generators[-1].prepare_bounds()
 
         for excluder in excluders:
-            axis_1, axis_2 = excluder.axes
-            gen_1 = [g for g in generators if axis_1 in g.axes][0]
-            gen_2 = [g for g in generators if axis_2 in g.axes][0]
-            gen_diff = generators.index(gen_1) \
-                - generators.index(gen_2)
-            if gen_diff < -1 or gen_diff > 1:
+            matched_dims = [d for d in self.dimensions if len(set(d.axes) & set(excluder.axes)) != 0]
+            if len(matched_dims) == 0:
                 raise ValueError(
-                    "Excluders must be defined on axes that are adjacent in " \
-                        "generator order")
-
-            # merge dimensions if region spans two
-            dim_1 = [i for i in self.dimensions if axis_1 in i.axes][0]
-            dim_2 = [i for i in self.dimensions if axis_2 in i.axes][0]
-            dim_diff = self.dimensions.index(dim_1) \
-                - self.dimensions.index(dim_2)
-            if dim_diff == 1:
-                dim_1, dim_2 = dim_2, dim_1
-                dim_diff = -1
-            if dim_1.alternate != dim_2.alternate \
-                    and dim_1 is not self.dimensions[0]:
-                raise ValueError(
-                    "Generators tied by regions must have the same " \
-                            "alternate setting")
-            # merge "inner" into "outer"
-            if dim_diff == -1:
-                # dim_1 is "outer" - preserves axis ordering
-                new_dim = Dimension.merge_dimensions(dim_1, dim_2)
-                self.dimensions[self.dimensions.index(dim_1)] = new_dim
-                self.dimensions.remove(dim_2)
-                dim = new_dim
+                        "Excluder references axes that have not been provided by generators: %s" % str(excluder.axes))
+            d_start = self.dimensions.index(matched_dims[0])
+            d_end = self.dimensions.index(matched_dims[-1])
+            if d_start != d_end:
+                # merge all excluders between d_start and d_end (inclusive)
+                alternate = self.dimensions[d_end].alternate
+                # verify consistent alternate settings (ignoring outermost dimesion where it doesn't matter)
+                for d in self.dimensions[max(1, d_start):d_end]:
+                    # filter out dimensions consisting of a single NullPointGenerator, since alternation means nothing
+                    if len(d.generators) == 1 and isinstance(d.generators[0], NullPointGenerator):
+                        continue
+                    if alternate != d.alternate:
+                        raise ValueError("Nested generators connected by regions must have the same alternate setting")
+                merged_dim = Dimension.merge_dimensions(self.dimensions[d_start:d_end+1])
+                self.dimensions = self.dimensions[:d_start] + [merged_dim] + self.dimensions[d_end+1:]
+                dim = merged_dim
             else:
-                dim = dim_1
-
+                dim = self.dimensions[d_start]
             dim.apply_excluder(excluder)
 
         self.size = 1

--- a/org.eclipse.scanning.points/scripts/scanpointgenerator/core/excluder.py
+++ b/org.eclipse.scanning.points/scripts/scanpointgenerator/core/excluder.py
@@ -27,7 +27,7 @@ class Excluder(object):
         """
         self.axes = axes
 
-    def create_mask(self, x_points, y_points):
+    def create_mask(self, *point_arrays):
         raise NotImplementedError("Method must be implemented in child class.")
 
     def to_dict(self):

--- a/org.eclipse.scanning.points/scripts/scanpointgenerator/excluders/roiexcluder.py
+++ b/org.eclipse.scanning.points/scripts/scanpointgenerator/excluders/roiexcluder.py
@@ -31,27 +31,28 @@ class ROIExcluder(Excluder):
 
         self.rois = rois
 
-    def create_mask(self, x_points, y_points):
+    def create_mask(self, *point_arrays):
         """Create a boolean array specifying the points to exclude.
 
         The resulting mask is created from the union of all ROIs.
 
         Args:
-            x_points(numpy.array(float)): Array of points for x-axis
-            y_points(numpy.array(float)): Array of points for y-axis
+            *point_arrays (numpy.array(float)): Array of points for each axis
 
         Returns:
             np.array(int8): Array of points to exclude
 
         """
-        if len(x_points) != len(y_points):
-            raise ValueError("Points lengths must be equal")
+        l = len(point_arrays[0])
+        for arr in point_arrays:
+            if len(arr) != l:
+                raise ValueError("Points lengths must be equal")
 
-        mask = np.zeros_like(x_points, dtype=np.int8)
+        mask = np.zeros_like(point_arrays[0], dtype=np.int8)
         for roi in self.rois:
             # Accumulate all True entries
             # Points outside of all ROIs will be excluded
-            mask |= roi.mask_points([x_points, y_points])
+            mask |= roi.mask_points(point_arrays)
 
         return mask
 

--- a/org.eclipse.scanning.points/scripts/scanpointgenerator/generators/__init__.py
+++ b/org.eclipse.scanning.points/scripts/scanpointgenerator/generators/__init__.py
@@ -17,3 +17,4 @@ from scanpointgenerator.generators.arraygenerator import ArrayGenerator
 from scanpointgenerator.generators.linegenerator import LineGenerator
 from scanpointgenerator.generators.lissajousgenerator import LissajousGenerator
 from scanpointgenerator.generators.spiralgenerator import SpiralGenerator
+from scanpointgenerator.generators.nullpointgenerator import NullPointGenerator

--- a/org.eclipse.scanning.points/scripts/scanpointgenerator/generators/nullpointgenerator.py
+++ b/org.eclipse.scanning.points/scripts/scanpointgenerator/generators/nullpointgenerator.py
@@ -1,0 +1,38 @@
+###
+# Copyright (c) 2017 Diamond Light Source Ltd.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#    Charles Mita - initial API and implementation and/or initial documentation
+#
+###
+
+from scanpointgenerator.core import Generator
+
+@Generator.register_subclass("scanpointgenerator:generator/NullPointGenerator:1.0")
+class NullPointGenerator(Generator):
+    """Generate 'empty' points with no axis information"""
+
+    def __init__(self, size):
+        self.size = size
+        self.units = {}
+        self.axes = []
+
+    def to_dict(self):
+        d = {
+                "typeid" : self.typeid,
+                "size" : self.size,
+            }
+        return d
+
+    def prepare_arrays(self, index_array):
+        return {}
+
+    @classmethod
+    def from_dict(cls, d):
+        size = d["size"]
+        return cls(size)


### PR DESCRIPTION
Changes since 2.1 release are the allowing of excluders on
non-consecutive generators, and the addition of the "continuous"
property on CompoundGenerator.

This also includes a WIP version of "NullPointGenerator" (name subject
to change) - this is a generator with no axes that produces empty
points - it can be put into a CompoundGenerator on its own, or
included with other generators, in which case it will "repeat" the
generators given after it (adding an additional Dimension).

Signed-off-by: Matthew Dickie <matthew.dickie@diamond.ac.uk>