### PR TITLE
[DAQ-1030] fix deserializing IPosition, broken in earlier change

### DIFF
--- a/org.eclipse.scanning.points/src/org/eclipse/scanning/points/serialization/PositionBean.java
+++ b/org.eclipse.scanning.points/src/org/eclipse/scanning/points/serialization/PositionBean.java
@@ -12,91 +12,41 @@
 package org.eclipse.scanning.points.serialization;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
 import org.eclipse.scanning.api.points.AbstractPosition;
 import org.eclipse.scanning.api.points.IPosition;
 import org.eclipse.scanning.api.points.MapPosition;
-import org.eclipse.scanning.api.points.Point;
-import org.eclipse.scanning.api.points.Scalar;
-import org.eclipse.scanning.api.points.StaticPosition;
 
-class PositionBean<T extends IPosition> {
+class PositionBean {
 
 	private Map<String, Object>  values;
 	private Map<String, Integer> indices;
 	private int stepIndex;
 	private List<Collection<String>> dimensionNames; // Dimension->Names@dimension
-	private Class<T> klass;
 
 	public PositionBean() {
-
+		// to be used for JSON deserialization only
 	}
+
 	public PositionBean(IPosition pos) {
 		this.values    = pos.getValues();
 		this.indices   = pos.getIndices();
 		this.stepIndex = pos.getStepIndex();
 		this.dimensionNames = getDimensionNames(pos);
-		@SuppressWarnings("unchecked")
-		Class<T> posKlass = (Class<T>) pos.getClass();
-		this.klass = posKlass;
 	}
 
 	private List<Collection<String>> getDimensionNames(IPosition pos) {
-		if (pos instanceof AbstractPosition) {
-			return ((AbstractPosition)pos).getDimensionNames();
-		}
-
+		if (pos instanceof AbstractPosition) return ((AbstractPosition)pos).getDimensionNames();
 		return null; // Do not have to support dimension names
 	}
 
 	public IPosition toPosition() {
-		if (klass == Point.class) {
-			return toPoint();
-		}
-
-		if (klass == Scalar.class) {
-			final String name = values.keySet().iterator().next();
-			final Object value = values.get(name);
-			final int index = indices.get(name);
-
-			return new Scalar<>(name, index, value);
-		}
-
-		if (klass == StaticPosition.class) {
-			return new StaticPosition();
-		}
-
-		// use map position by default
-		final MapPosition pos = new MapPosition(values, indices);
+		MapPosition pos = new MapPosition(values, indices);
 		pos.setStepIndex(stepIndex);
 		pos.setDimensionNames(dimensionNames);
 		return pos;
-	}
-
-	private IPosition toPoint() {
-		final String xName;
-		final String yName;
-		final boolean is2D;
-		if (dimensionNames.get(0).size() == 1) {
-			yName = dimensionNames.get(0).iterator().next(); // yName is listed first
-			xName = dimensionNames.get(1).iterator().next();
-			is2D = true;
-		} else {
-			Iterator<String> namesIter = dimensionNames.get(0).iterator();
-			yName = namesIter.next();
-			xName = namesIter.next();
-			is2D = false;
-		}
-
-		final int xIndex = indices.get(xName);
-		final double xPosition = (Double) values.get(xName);
-		final int yIndex = indices.get(yName);
-		final double yPosition = (Double) values.get(yName);
-
-		return new Point(xName, xIndex, xPosition, yName, yIndex, yPosition, stepIndex, is2D);
 	}
 
 	public Map<String, Object> getValues() {
@@ -110,7 +60,6 @@ class PositionBean<T extends IPosition> {
 	public Map<String, Integer> getIndices() {
 		return indices;
 	}
-
 	public void setIndices(Map<String, Integer> indices) {
 		this.indices = indices;
 	}
@@ -131,14 +80,6 @@ class PositionBean<T extends IPosition> {
 		this.dimensionNames = dimensionNames;
 	}
 
-	public Class<T> getPositionClass() {
-		return klass;
-	}
-
-	public void setPositionClass(Class<T> klass) {
-		this.klass = klass;
-	}
-
 	@Override
 	public int hashCode() {
 		final int prime = 31;
@@ -146,7 +87,6 @@ class PositionBean<T extends IPosition> {
 		result = prime * result + ((dimensionNames == null) ? 0 : dimensionNames.hashCode());
 		result = prime * result + ((indices == null) ? 0 : indices.hashCode());
 		result = prime * result + stepIndex;
-		result = prime * result + ((klass == null) ? 0 : klass.hashCode());
 		result = prime * result + ((values == null) ? 0 : values.hashCode());
 		return result;
 	}
@@ -159,7 +99,7 @@ class PositionBean<T extends IPosition> {
 			return false;
 		if (getClass() != obj.getClass())
 			return false;
-		PositionBean<?> other = (PositionBean<?>) obj;
+		PositionBean other = (PositionBean) obj;
 		if (dimensionNames == null) {
 			if (other.dimensionNames != null)
 				return false;
@@ -171,11 +111,6 @@ class PositionBean<T extends IPosition> {
 		} else if (!indices.equals(other.indices))
 			return false;
 		if (stepIndex != other.stepIndex)
-			return false;
-		if (klass == null) {
-			if (other.klass != null)
-				return false;
-		} else if (!klass.equals(other.klass))
 			return false;
 		if (values == null) {
 			if (other.values != null)

--- a/org.eclipse.scanning.points/src/org/eclipse/scanning/points/serialization/PositionDeserializer.java
+++ b/org.eclipse.scanning.points/src/org/eclipse/scanning/points/serialization/PositionDeserializer.java
@@ -25,7 +25,7 @@ public class PositionDeserializer extends JsonDeserializer<IPosition> {
 
 	@Override
 	public IPosition deserialize(JsonParser parser, DeserializationContext context) throws IOException, JsonProcessingException {
-		PositionBean<?> bean = parser.readValueAs(PositionBean.class);
+		PositionBean bean = parser.readValueAs(PositionBean.class);
 		return bean.toPosition();
 	}
 

--- a/org.eclipse.scanning.points/src/org/eclipse/scanning/points/serialization/PositionSerializer.java
+++ b/org.eclipse.scanning.points/src/org/eclipse/scanning/points/serialization/PositionSerializer.java
@@ -27,7 +27,7 @@ public class PositionSerializer extends JsonSerializer<IPosition> {
 	public void serialize(IPosition pos, JsonGenerator gen, SerializerProvider prov) throws IOException, JsonProcessingException {
 
 		try {
-			final PositionBean<?> bean = new PositionBean<>(pos);
+			final PositionBean bean = new PositionBean(pos);
 			gen.writeObject(bean);
 		} catch (Throwable ne) {
 			ne.printStackTrace();


### PR DESCRIPTION
A previous change attempted to restore IPositions to the same class as
previously, i.e. one of StaticPosition, Scalar, Point or MapPosition.
This was done by adding a positionClass field to PositionBean.
This causes a ClassNotFoundException for MapPosition for some reason,
so this change reverts that change. Another fix would have been to
use a string for the class, but this could have a performance impact.