### PR TITLE
Fix PolygonROIExpresser

### DIFF
--- a/org.eclipse.scanning.command/scripts/mapping_scan_commands.py
+++ b/org.eclipse.scanning.command/scripts/mapping_scan_commands.py
@@ -595,7 +595,7 @@ def poly(*vertices):
     point_rois = map(lambda (x, y): PointROI(x, y), vertices)
 
     # PolygonalROI closes the polygon for us.
-    return PolygonalROI(PolylineROI(*point_rois))
+    return PolygonalROI(PolylineROI(point_rois))
 
 
 def rect(origin=None, size=None, angle=0):

--- a/org.eclipse.scanning.command/src/org/eclipse/scanning/command/factory/PolygonalROIExpresser.java
+++ b/org.eclipse.scanning.command/src/org/eclipse/scanning/command/factory/PolygonalROIExpresser.java
@@ -19,17 +19,21 @@ class PolygonalROIExpresser extends PyModelExpresser<PolygonalROI> {
 
 	@Override
 	public String pyExpress(PolygonalROI proi, boolean verbose) {
-		// TODO Use StringBuilder
-		String fragment = "poly(";
+		StringBuilder fragment = new StringBuilder();
+		fragment.append("poly(");
 
 		boolean pointListPartiallyWritten = false;
 		for (IROI p : proi.getPoints()) {
-			if (pointListPartiallyWritten) fragment += ", ";
-			fragment += "("+((PointROI) p).getPointX()+", "+((PointROI) p).getPointY()+")";
+			if (pointListPartiallyWritten) fragment.append(", ");
+			fragment.append("(")
+					.append(((PointROI) p).getPointX())
+					.append(", ")
+					.append(((PointROI) p).getPointY())
+					.append(")");
+			pointListPartiallyWritten |= true;
 		}
 
-		fragment += ")";
-		return fragment;
+		return fragment.append(")").toString();
 	}
 
 }

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/command/PyExpresserTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/command/PyExpresserTest.java
@@ -17,10 +17,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.dawnsci.analysis.api.roi.IROI;
 import org.eclipse.dawnsci.analysis.dataset.roi.CircularROI;
+import org.eclipse.dawnsci.analysis.dataset.roi.PointROI;
+import org.eclipse.dawnsci.analysis.dataset.roi.PolygonalROI;
+import org.eclipse.dawnsci.analysis.dataset.roi.PolylineROI;
 import org.eclipse.scanning.api.device.models.ClusterProcessingModel;
 import org.eclipse.scanning.api.event.scan.ScanRequest;
 import org.eclipse.scanning.api.points.models.ArrayModel;
@@ -289,6 +293,38 @@ public class PyExpresserTest {
 		assertEquals(  // Verbose.
 				"grid(axes=('myFast', 'mySlow'), start=(0.0, 1.0), stop=(10.0, 12.0), count=(3, 4), snake=True, continuous=True)",
 				factory.pyExpress(gmodel, new ArrayList<>(), true));
+	}
+
+	@Test
+	public void testGridModelWithPolygonalROI() throws Exception {
+
+		BoundingBox bbox = new BoundingBox();
+		bbox.setFastAxisStart(0);
+		bbox.setSlowAxisStart(1);
+		bbox.setFastAxisLength(10);
+		bbox.setSlowAxisLength(11);
+
+		GridModel gmodel = new GridModel();
+		gmodel.setFastAxisName("myFast");
+		gmodel.setSlowAxisName("mySlow");
+		gmodel.setBoundingBox(bbox);
+		gmodel.setFastAxisPoints(3);
+		gmodel.setSlowAxisPoints(4);
+		gmodel.setSnake(true);
+		gmodel.setContinuous(true);
+
+		List<PointROI> points = new ArrayList<>();
+		points.add(new PointROI(0, 0));
+		points.add(new PointROI(0, 1));
+		points.add(new PointROI(1, 0));
+		PolygonalROI roi = new PolygonalROI(new PolylineROI(points));
+
+		assertEquals(  // Concise.
+				"grid(('myFast', 'mySlow'), (0.0, 1.0), (10.0, 12.0), count=(3, 4), roi=poly((0.0, 0.0), (0.0, 1.0), (1.0, 0.0)))",
+				factory.pyExpress(gmodel, Arrays.asList(roi), false));
+		assertEquals(  // Verbose.
+				"grid(axes=('myFast', 'mySlow'), start=(0.0, 1.0), stop=(10.0, 12.0), count=(3, 4), snake=True, continuous=True, roi=[poly((0.0, 0.0), (0.0, 1.0), (1.0, 0.0))])",
+				factory.pyExpress(gmodel, Arrays.asList(roi), true));
 	}
 
 	@Test

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/command/ScanRequestCreationTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/command/ScanRequestCreationTest.java
@@ -16,7 +16,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 
 import org.eclipse.dawnsci.analysis.api.roi.IROI;
@@ -35,6 +34,7 @@ import org.eclipse.scanning.api.points.models.RasterModel;
 import org.eclipse.scanning.api.points.models.RepeatedPointModel;
 import org.eclipse.scanning.api.points.models.SinglePointModel;
 import org.eclipse.scanning.api.points.models.StepModel;
+import org.eclipse.scanning.api.scan.ScanningException;
 import org.eclipse.scanning.command.Services;
 import org.eclipse.scanning.connector.activemq.ActivemqConnectorService;
 import org.eclipse.scanning.event.EventServiceImpl;
@@ -63,7 +63,7 @@ public class ScanRequestCreationTest extends AbstractJythonTest {
 	}
 
 	@Before
-	public void before() throws Exception {
+	public void before() throws ScanningException {
 
 		createMarshaller();
 		service = new PointGeneratorService();
@@ -88,7 +88,7 @@ public class ScanRequestCreationTest extends AbstractJythonTest {
 	}
 
 	@Test
-	public void testGridCommandWithROI() throws Exception {
+	public void testGridCommandWithROI() throws GeneratorException {
 		pi.exec("sr =                             "
 			+	"scan_request(                    "
 			+	"    grid(                        "
@@ -144,7 +144,7 @@ public class ScanRequestCreationTest extends AbstractJythonTest {
 	}
 
 	@Test
-	public void testGridCommandWithROINoDetector() throws Exception {
+	public void testGridCommandWithROINoDetector() throws GeneratorException {
 		pi.exec("sr =                             "
 			+	"scan_request(                    "
 			+	"    grid(                        "
@@ -226,7 +226,7 @@ public class ScanRequestCreationTest extends AbstractJythonTest {
 		assertEquals(-2., poly.getPoint(2).getPointY(), 1e-8);
 	}
 	@Test
-	public void testStepCommandWithMonitors() throws Exception {
+	public void testStepCommandWithMonitors() {
 		pi.exec("sr =                               "
 			+	"scan_request(                      "
 			+	"    step(my_scannable, -2, 5, 0.5),"
@@ -236,7 +236,7 @@ public class ScanRequestCreationTest extends AbstractJythonTest {
 		@SuppressWarnings("unchecked")
 		ScanRequest<IROI> request = pi.get("sr", ScanRequest.class);
 
-		Object model = ((List<Object>) request.getCompoundModel().getModels()).get(0);
+		Object model = request.getCompoundModel().getModels().get(0);
 		assertEquals(StepModel.class, model.getClass());
 
 		StepModel smodel = (StepModel) model;
@@ -253,7 +253,7 @@ public class ScanRequestCreationTest extends AbstractJythonTest {
 	}
 
 	@Test
-	public void testStepCommandWithMonitorsNoDetector() throws Exception {
+	public void testStepCommandWithMonitorsNoDetector() {
 		pi.exec("sr =                               "
 			+	"scan_request(                      "
 			+	"    step(my_scannable, -2, 5, 0.5),"
@@ -262,7 +262,7 @@ public class ScanRequestCreationTest extends AbstractJythonTest {
 		@SuppressWarnings("unchecked")
 		ScanRequest<IROI> request = pi.get("sr", ScanRequest.class);
 
-		Object model = ((List<Object>) request.getCompoundModel().getModels()).get(0);
+		Object model = request.getCompoundModel().getModels().get(0);
 		assertEquals(StepModel.class, model.getClass());
 
 		StepModel smodel = (StepModel) model;
@@ -279,7 +279,7 @@ public class ScanRequestCreationTest extends AbstractJythonTest {
 	}
 
 	@Test
-	public void testRepeatCommandWithMonitors() throws Exception {
+	public void testRepeatCommandWithMonitors() {
 		pi.exec("sr =                               "
 			+	"scan_request(                      "
 			+	"    repeat(my_scannable, 10, 2.2, 25),"
@@ -289,7 +289,7 @@ public class ScanRequestCreationTest extends AbstractJythonTest {
 		@SuppressWarnings("unchecked")
 		ScanRequest<IROI> request = pi.get("sr", ScanRequest.class);
 
-		Object model = ((List<Object>) request.getCompoundModel().getModels()).get(0);
+		Object model = request.getCompoundModel().getModels().get(0);
 		assertEquals(RepeatedPointModel.class, model.getClass());
 
 		RepeatedPointModel smodel = (RepeatedPointModel) model;
@@ -306,7 +306,7 @@ public class ScanRequestCreationTest extends AbstractJythonTest {
 	}
 
 	@Test
-	public void testRepeatCommandWithMonitorsNoDetector() throws Exception {
+	public void testRepeatCommandWithMonitorsNoDetector() {
 		pi.exec("sr =                               "
 			+	"scan_request(                      "
 			+	"    repeat(my_scannable, 10, 2.2, 25),"
@@ -315,7 +315,7 @@ public class ScanRequestCreationTest extends AbstractJythonTest {
 		@SuppressWarnings("unchecked")
 		ScanRequest<IROI> request = pi.get("sr", ScanRequest.class);
 
-		Object model = ((List<Object>) request.getCompoundModel().getModels()).get(0);
+		Object model = request.getCompoundModel().getModels().get(0);
 		assertEquals(RepeatedPointModel.class, model.getClass());
 
 		RepeatedPointModel smodel = (RepeatedPointModel) model;
@@ -332,7 +332,7 @@ public class ScanRequestCreationTest extends AbstractJythonTest {
 	}
 
 	@Test
-	public void testRasterCommandWithROIs() throws Exception {
+	public void testRasterCommandWithROIs() throws GeneratorException {
 		pi.exec("sr =                                 "
 			+	"scan_request(                        "
 			+	"    grid(                            "
@@ -375,7 +375,7 @@ public class ScanRequestCreationTest extends AbstractJythonTest {
 	}
 
 	@Test
-	public void testRasterCommandWithROIsNoDetector() throws Exception {
+	public void testRasterCommandWithROIsNoDetector() throws GeneratorException {
 		pi.exec("sr =                                 "
 			+	"scan_request(                        "
 			+	"    grid(                            "
@@ -417,7 +417,7 @@ public class ScanRequestCreationTest extends AbstractJythonTest {
 	}
 
 	@Test
-	public void testArrayCommand() throws Exception {
+	public void testArrayCommand() {
 		pi.exec("sr =                                 "
 			+	"scan_request(                        "
 			+	"    array('qty', [-3, 1, 1.5, 1e10]),"
@@ -438,7 +438,7 @@ public class ScanRequestCreationTest extends AbstractJythonTest {
 	}
 
 	@Test
-	public void testOneDEqualSpacingCommand() throws Exception {
+	public void testOneDEqualSpacingCommand() {
 		pi.exec("sr =                                                    "
 			+	"scan_request(                                           "
 			+	"    line(origin=(0, 4), length=10, angle=0.1, count=10),"
@@ -459,7 +459,7 @@ public class ScanRequestCreationTest extends AbstractJythonTest {
 	}
 
 	@Test
-	public void testOneDStepCommand() throws Exception {
+	public void testOneDStepCommand() {
 		pi.exec("sr =                                                       "
 			+	"scan_request(                                              "
 			+	"    line(origin=(-2, 1.3), length=10, angle=0.1, step=0.5),"
@@ -480,7 +480,7 @@ public class ScanRequestCreationTest extends AbstractJythonTest {
 	}
 
 	@Test
-	public void testSinglePointCommand() throws Exception {
+	public void testSinglePointCommand() {
 		pi.exec("sr = scan_request(point(4, 5), det=mandelbrot(0.1))");
 		@SuppressWarnings("unchecked")
 		ScanRequest<IROI> request = pi.get("sr", ScanRequest.class);
@@ -503,7 +503,7 @@ public class ScanRequestCreationTest extends AbstractJythonTest {
 	}
 
 	@Test
-	public void testSquareBracketCombinations() throws Exception {
+	public void testSquareBracketCombinations() {
 		pi.exec("sr0 = scan_request(point(4, 5), det=detector('mandelbrot', 0.1))");
 		pi.exec("sr1 = scan_request([point(4, 5)], det=detector('mandelbrot', 0.1))");
 		pi.exec("sr2 = scan_request(point(4, 5), det=[detector('mandelbrot', 0.1)])");
@@ -532,7 +532,7 @@ public class ScanRequestCreationTest extends AbstractJythonTest {
 	}
 
 	@Test
-	public void testCompoundCommand() throws Exception {
+	public void testCompoundCommand() {
 		pi.exec("sr =                                                                                 "
 			+	"scan_request(                                                                        "
 			+	"    path=[                                                                           "
@@ -556,7 +556,7 @@ public class ScanRequestCreationTest extends AbstractJythonTest {
 	}
 
 	@Test
-	public void testMoveToKeepStillCommand() throws Exception {
+	public void testMoveToKeepStillCommand() {
 		pi.exec("sr =                                              "
 			+	"scan_request(                                     "
 			+	"    [step(my_scannable, -2, 5, 0.5), val('y', 5)],"
@@ -577,7 +577,7 @@ public class ScanRequestCreationTest extends AbstractJythonTest {
 	}
 
 	@Test
-	public void testMoveToKeepStillCommandNoDetector() throws Exception {
+	public void testMoveToKeepStillCommandNoDetector() {
 		pi.exec("sr =                                              "
 			+	"scan_request(                                     "
 			+	"    [step(my_scannable, -2, 5, 0.5), val('y', 5)]"
@@ -599,7 +599,7 @@ public class ScanRequestCreationTest extends AbstractJythonTest {
 
 	@Ignore("ScanRequest<?>.equals() doesn't allow this test to work.")
 	@Test
-	public void testArgStyleInvariance() throws Exception {
+	public void testArgStyleInvariance() {
 		pi.exec("sr_full =                     "
 			+	"scan_request(                 "
 			+	"    path=grid(                "


### PR DESCRIPTION
pointListPartiallyWritten was always false, so commas separating points were missing. Also fixed the call to PolylineROI constructor.

Signed-off-by: Douglas Winter <douglas.winter@diamond.ac.uk>